### PR TITLE
ci: github actions CI 스크립트 작성

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,39 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "dev" ]
+  pull_request:
+    types: [ "closed" ]
+    branches: [ "dev" ]
+
+env:
+  DOCKER_IMAGE: ghcr.io/boostcampwm-2024/web18-inear
+  VERSION: ${{ github.sha }}
+
+jobs:
+  build:
+    name: Build
+    if: github.event.pull_request.merged == true || github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    steps:
+      # SSH 접속을 위한 SSH 키 설정
+      - name: Set up SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      # 원격 서버의 SSH 키를 파일에 추가하는 프로세스
+      - name: Add known hosts
+        run: ssh-keyscan -H ${{ secrets.SERVER_IP }} >> ~/.ssh/known_hosts
+
+      # 서버에서 Docker Compose를 사용해 컨테이너를 빌드하고 배포합니다.
+      - name: Deploy with Docker Compose on server
+        run: |
+          ssh ${{ secrets.SSH_USER }}@${{ secrets.SERVER_IP }} << 'EOF'
+          cd /${{ secrets.SSH_USER }}/web18-inear
+          git pull origin dev
+          cd ${{ secrets.SCRIPT_PATH }}
+          ./deploy.sh
+          EOF
+        


### PR DESCRIPTION
close #25 

## 📋개요

깃허브 액션을 활용한 자동 CI 스크립트 작성

## 🕰️예상 리뷰시간

2분

## 📢상세내용

- 모노레포 환경에서 자동으로 서버에 배포하기 위한 스크립트 작성
- GitHub Actions를 활용하여 자동으로 서버에 접속 후, 파일 버전 최신화 후 배포 작업 수행

![image](https://github.com/user-attachments/assets/72fb044f-f765-487e-8699-2d97e3c65980)

## 💥특이사항