### PR TITLE
fix: 랜덤 동물 이름 생성 시 undeined가 생기지 않도록 개선

### DIFF
--- a/server/src/common/randomname/random-name.util.ts
+++ b/server/src/common/randomname/random-name.util.ts
@@ -59,13 +59,13 @@ export class RandomNameUtil {
     '토끼',
   ];
 
-  static generate() {
+  public static generate() {
     const adjectvieLength = RandomNameUtil.adjective.length;
     const animalLength = RandomNameUtil.animal.length;
 
-    const adjectvieIndex = Math.random() * (adjectvieLength + 1);
-    const animalIndex = Math.random() * (animalLength + 1);
+    const adjectvieIndex = Math.floor(Math.random() * adjectvieLength);
+    const animalIndex = Math.floor(Math.random() * animalLength);
 
-    return `${RandomNameUtil.adjective[Math.floor(adjectvieIndex)]} ${RandomNameUtil.animal[Math.floor(animalIndex)]}`;
+    return `${RandomNameUtil.adjective[adjectvieIndex]} ${RandomNameUtil.animal[animalIndex]}`;
   }
 }


### PR DESCRIPTION
close #45 

## 📋개요

- 사용자의 랜덤 동물 이름을 생성할 때, undefined가 생기는 문제에 대한 해결

## 🕰️예상 리뷰시간

## 📢상세내용

- 기존 코드인 `animalLength + 1`에서 `+1` 부분을 제거

## 💥특이사항