### PR TITLE
[BE] 입/퇴장 시 카운트 이벤트 적용 및 퇴장 오류 수정

### DIFF
--- a/server/public/socket-test.html
+++ b/server/public/socket-test.html
@@ -45,19 +45,16 @@
 
     <div class="container">
       <div>
-        <input type="text" id="createUserId" placeholder="User ID" />
         <button onclick="createRoom()">Create Room</button>
       </div>
 
       <div>
         <input type="text" id="joinRoomId" placeholder="Room ID" />
-        <input type="text" id="joinUserId" placeholder="User ID" />
         <button onclick="joinRoom()">Join Room</button>
       </div>
 
       <div>
         <input type="text" id="leaveRoomId" placeholder="Room ID" />
-        <input type="text" id="leaveUserId" placeholder="User ID" />
         <button onclick="leaveRoom()">Leave Room</button>
       </div>
 
@@ -87,6 +84,7 @@
         socket.emit('message', { message: input.value, roomId: roomIdDom.innerHTML }, (response) => {
           addEvent(`response: ${JSON.stringify(response)}`);
         });
+        input.value = ''; // 메시지 전송 후 입력창 비우기
       });
 
       function socketInit(socket) {
@@ -114,13 +112,18 @@
           addEvent(`Joined Room: ${JSON.stringify(data, null, 2)}`);
         });
 
-        // 유저 퇴장 이벤트 리스너
-        socket.on('userLeft', (data) => {
-          addEvent(`User Left: ${JSON.stringify(data, null, 2)}`);
+        // 방 나가기 이벤트 리스너
+        socket.on('leavedRoom', (data) => {
+          addEvent(`Left Room: ${JSON.stringify(data, null, 2)}`);
         });
 
+        // 사용자 수 업데이트 이벤트 리스너
+        socket.on('roomUsersUpdated', (data) => {
+          addEvent(`Room Users Updated: ${JSON.stringify(data, null, 2)}`);
+        });
+
+        // 채팅 메시지 수신 리스너
         socket.on('broadcast', (data) => {
-          console.log(data);
           const { userName, userId, message } = data;
           addEvent(`${userName}(${userId}): ${message}`);
         });
@@ -128,31 +131,24 @@
 
       // 방 생성 함수
       function createRoom() {
-        const userId = document.getElementById('createUserId').value;
-        if (!userId) {
-          addEvent('Error: Please enter a User ID');
-          return;
-        }
-
-        socket.emit('createRoom', { userId }, (response) => {
-          addEvent(
-            `Create Room Response: ${JSON.stringify(response, null, 2)}`,
-          );
+        socket.emit('createRoom', null, (response) => {
+          addEvent(`Create Room Response: ${JSON.stringify(response, null, 2)}`);
+          if (response.success && response.room) {
+            roomIdDom.innerHTML = response.room.id; // 생성된 방 ID를 화면에 표시
+          }
         });
       }
 
       // 방 입장 함수
       function joinRoom() {
         const roomId = document.getElementById('joinRoomId').value;
-        const userId = document.getElementById('joinUserId').value;
-
-        if (!roomId || !userId) {
-          addEvent('Error: Please enter both Room ID and User ID');
+        if (!roomId) {
+          addEvent('Error: Please enter Room ID');
           return;
         }
 
         roomIdDom.innerHTML = roomId; // 브라우저에 보여지는 방 번호 업데이트
-        socket.emit('joinRoom', { roomId, userId }, (response) => {
+        socket.emit('joinRoom', { roomId }, (response) => {
           addEvent(`Join Room Response: ${JSON.stringify(response, null, 2)}`);
         });
       }
@@ -160,15 +156,16 @@
       // 방 퇴장 함수
       function leaveRoom() {
         const roomId = document.getElementById('leaveRoomId').value;
-        const userId = document.getElementById('leaveUserId').value;
-
-        if (!roomId || !userId) {
-          addEvent('Error: Please enter both Room ID and User ID');
+        if (!roomId) {
+          addEvent('Error: Please enter Room ID');
           return;
         }
 
-        socket.emit('leaveRoom', { roomId, userId }, (response) => {
+        socket.emit('leaveRoom', { roomId }, (response) => {
           addEvent(`Leave Room Response: ${JSON.stringify(response, null, 2)}`);
+          if (response.success) {
+            roomIdDom.innerHTML = 'room_1'; // 기본 방 번호로 초기화
+          }
         });
       }
 
@@ -176,7 +173,7 @@
       function addEvent(message) {
         const timestamp = new Date().toLocaleTimeString();
         eventsDiv.textContent = `${eventsDiv.textContent}[${timestamp}]\n ${message}\n`;
-        eventsDiv.textContent += `===============`;
+        eventsDiv.textContent += `===============\n`;
         eventsDiv.scrollTop = eventsDiv.scrollHeight;
       }
 

--- a/server/src/room/room.entity.ts
+++ b/server/src/room/room.entity.ts
@@ -1,6 +1,5 @@
 export class Room {
   id: string;
-  name: string;
   hostId: string;
   createdAt: Date;
   

--- a/server/src/room/room.gateway.ts
+++ b/server/src/room/room.gateway.ts
@@ -46,11 +46,12 @@ export class RoomGateway
     try {
       const clientId = client.id;
       const roomId = await this.roomRepository.generateRoomId();
-      const name = RandomNameUtil.generate();
 
+      if (client.data.name === undefined) {
+        client.data.name = RandomNameUtil.generate();
+      }
       const room = new Room({
         id: roomId,
-        name,
         hostId: clientId,
         createdAt: new Date(),
       });
@@ -61,7 +62,6 @@ export class RoomGateway
 
       client.emit('roomCreated', {
         roomId: room.id,
-        name: room.name,
         hostId: room.hostId,
       });
 

--- a/server/src/room/room.gateway.ts
+++ b/server/src/room/room.gateway.ts
@@ -187,7 +187,6 @@ export class RoomGateway
         roomId,
         userCount: currentUserCount,
       });
-      data.roomId = undefined;
 
       return {
         success: true,

--- a/server/src/room/room.gateway.ts
+++ b/server/src/room/room.gateway.ts
@@ -119,6 +119,12 @@ export class RoomGateway
   ): Promise<{ success: boolean; message?: string; error?: string }> {
     console.log('joinRoom event received', data);
     try {
+      const room = await this.roomRepository.findRoom(data.roomId);
+
+      if (!room) {
+        throw new Error('Room not found');
+      }
+
       await this.roomRepository.joinRoom(data.userId, data.roomId);
 
       const currentUserCount = await this.roomRepository.getCurrentUsers(

--- a/server/src/room/room.gateway.ts
+++ b/server/src/room/room.gateway.ts
@@ -59,7 +59,7 @@ export class RoomGateway
 
       await this.roomRepository.createRoom(roomId, room);
 
-      this.server.emit('roomCreated', {
+      client.emit('roomCreated', {
         roomId: room.id,
         name: room.name,
         hostId: room.hostId,

--- a/server/src/room/room.repository.ts
+++ b/server/src/room/room.repository.ts
@@ -35,7 +35,6 @@ export class RoomRepository {
     await this.redisClient
       .multi()
       .hSet(roomKey, 'id', room.id)
-      .hSet(roomKey, 'name', room.name)
       .hSet(roomKey, 'hostId', room.hostId)
       .hSet(roomKey, 'createdAt', room.createdAt.toISOString())
       .hSet(roomKey, 'isActive', 'true')
@@ -88,7 +87,6 @@ export class RoomRepository {
 
     return new Room({
       id,
-      name,
       hostId,
       createdAt: new Date(createdAt),
     });

--- a/server/src/room/room.repository.ts
+++ b/server/src/room/room.repository.ts
@@ -122,4 +122,10 @@ export class RoomRepository {
 
     await multi.exec();
   }
+
+  async getCurrentUsers(roomId: string): Promise<number> {
+    const roomKey = this.roomKey(roomId);
+    const currentUsers = await this.redisClient.hGet(roomKey, 'currentUsers');
+    return parseInt(currentUsers || '0', 10);
+  }
 }


### PR DESCRIPTION
close #44 
close #40 
## 📋개요
- 방 입장 / 퇴장 / 방 생성할 시 입장 => 현재 유저 수 이벤트 발생
- 기존 프론트에서 body로 userId 받아오는 방식에서 client.id로 수정
- ~~방 퇴장 시, 퇴장해도 기존 방에 브로드캐스팅 할 수 있었던 점 수정~~
## 🕰️예상 리뷰시간
5분
## 📢상세내용
![2024-11-13 19-03-01](https://github.com/user-attachments/assets/bcab273c-9f95-40f5-a89e-b48f5f3aed26)

## 💥특이사항
퇴장시켜도 `data.roomId` 는 그대로 저장되어있기에, 계속 broadcasting을 하는 오류가 발생했습니다.

~~일단 `data.roomId = undefined`로 명시를 해준 상태입니다.~~