### PR TITLE
음악 스트리밍 사용자 입장 시간 계산 로직 수정

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -23,6 +23,9 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api/api-document', app, document);
 
+  app.useStaticAssets(join(__dirname, '..', 'public'), {
+    prefix: '/',
+  });
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -27,5 +27,9 @@ async function bootstrap() {
     prefix: '/',
   });
   await app.listen(process.env.PORT ?? 3000);
+  app.enableCors({
+    origin: ['http://localhost:5173', 'https://www.inear.live'],
+    credentials: true,
+  });
 }
 bootstrap();

--- a/server/src/music/music.controller.ts
+++ b/server/src/music/music.controller.ts
@@ -15,10 +15,10 @@ import { MusicService } from './music.service';
 export class MusicController {
   constructor(private readonly musicService: MusicService) {}
 
-  @Get(':musicId/playlist.m3u8')
+  @Get(':albumId/playlist.m3u8')
   @Header('Content-Type', 'application/x-mpegURL')
   async getMusicFile(
-    @Param('musicId') musicId: string,
+    @Param('albumId') albumId: string,
     @Query('joinTimeStamp') joinTimeStamp: string,
   ) {
     if (!joinTimeStamp) {
@@ -29,19 +29,20 @@ export class MusicController {
     }
 
     return await this.musicService.generateMusicFile(
-      musicId,
+      albumId,
       parseInt(joinTimeStamp, 10),
     );
   }
 
-  @Get(':musicId/playlist:segmentId.ts')
+  @Get(':albumId/:songIndex/playlist:segmentId.ts')
   @Header('Content-Type', 'video/MP2T')
   async getSegment(
-    @Param('musicId') musicId: string,
+    @Param('albumId') albumId: string,
+    @Param('songIndex') songIndex: string,
     @Param('segmentId') segmentId: string,
   ) {
     return new StreamableFile(
-      await this.musicService.getSegment(musicId, segmentId),
+      await this.musicService.getSegment(albumId, songIndex, segmentId),
       { type: 'video/MP2T' },
     );
   }

--- a/server/src/music/music.repository.ts
+++ b/server/src/music/music.repository.ts
@@ -58,7 +58,7 @@ export class MusicRepository {
 
       if (joinTimestamp >= currentTime && joinTimestamp < songEndTime) {
         return {
-          id: `${i}`,
+          id: `${i + 1}`,
           startTime: currentTime,
           duration: session.songs[i],
         };

--- a/server/src/music/music.service.ts
+++ b/server/src/music/music.service.ts
@@ -33,27 +33,17 @@ export class MusicService {
     });
   }
 
-  private validatePlayingTime(elapsedTime: number, duration: number): void {
-    // 곡이 시작 전일 때
-    if (elapsedTime < 0) {
-      throw new HttpException(
-        'Song has not started yet',
-        HttpStatus.BAD_REQUEST,
-      );
-    }
-    // 곡이 끝난 뒤일 때
-    if (elapsedTime > duration * 1000) {
-      throw new HttpException('Song has already ended', HttpStatus.BAD_REQUEST);
-    }
-  }
-
   async generateMusicFile(
-    musicId: string,
+    albumId: string,
     joinTimestamp: number,
   ): Promise<string> {
-    const songMetadata = await this.musicRepository.getSongMetadata(musicId);
+    const songMetadata = await this.musicRepository.findSongByJoinTimestamp(
+      albumId,
+      joinTimestamp,
+    );
+    const songIndex = songMetadata.id;
 
-    const cacheKey = `m3u8:${musicId}`;
+    const cacheKey = `m3u8:${albumId}:${songIndex}`;
     let cachedM3u8 = await this.cacheManager.get<string>(cacheKey);
 
     // 원본 가져오기
@@ -62,7 +52,7 @@ export class MusicService {
         const s3Response = await this.s3
           .getObject({
             Bucket: this.configService.get('S3_BUCKET_NAME'),
-            Key: `converted/18dfb0c0-fb45-409c-8bac-a3ff02fef9e0/${musicId}/playlist.m3u8`, // 폴더 구조 동기화 필요
+            Key: `converted/${albumId}/${parseInt(songIndex, 10) + 1}/playlist.m3u8`, // 일단 songIndex 경로로 가져옴
           })
           .promise();
 
@@ -73,28 +63,33 @@ export class MusicService {
           songMetadata.duration * 1000,
         );
       } catch (error) {
-        throw new NotFoundException(`file not found for ${musicId}`);
+        throw new NotFoundException(
+          `file not found for ${albumId}, song index ${songIndex}`,
+        );
       }
     }
 
     const elapsedTime = joinTimestamp - songMetadata.startTime;
-    this.validatePlayingTime(elapsedTime, songMetadata.duration);
     const skipSegments = Math.floor(
       elapsedTime / (this.SEGMENT_DURATION * 1000),
     );
 
-    return this.m3u8Parser.parse(cachedM3u8, skipSegments);
+    return this.m3u8Parser.parse(cachedM3u8, skipSegments, albumId, songIndex);
   }
 
-  async getSegment(musicId: string, segmentId: string): Promise<Buffer> {
-    const cacheKey = `segment:${musicId}:${segmentId}`;
+  async getSegment(
+    albumId: string,
+    songIndex: string,
+    segmentId: string,
+  ): Promise<Buffer> {
+    const cacheKey = `segment:${albumId}:${songIndex}:${segmentId}`;
     let segment = await this.cacheManager.get<Buffer>(cacheKey);
     if (!segment) {
       try {
         const s3Response = await this.s3
           .getObject({
             Bucket: this.configService.get('S3_BUCKET_NAME'),
-            Key: `converted/18dfb0c0-fb45-409c-8bac-a3ff02fef9e0/${musicId}/playlist${segmentId}.ts`, // 폴더 구조 동기화 필요
+            Key: `converted/${albumId}/${parseInt(songIndex, 10) + 1}/playlist${segmentId}.ts`, // 폴더 구조 동기화 필요
           })
           .promise();
 
@@ -102,7 +97,7 @@ export class MusicService {
         await this.cacheManager.set(cacheKey, segment, 3600000);
       } catch (error) {
         console.error(
-          `Failed to fetch segment ${segmentId} for ${musicId}:`,
+          `Failed to fetch segment ${segmentId} for ${albumId}:`,
           error,
         );
         throw new NotFoundException(`Segment not found: ${segmentId}`);

--- a/server/src/music/music.service.ts
+++ b/server/src/music/music.service.ts
@@ -52,7 +52,7 @@ export class MusicService {
         const s3Response = await this.s3
           .getObject({
             Bucket: this.configService.get('S3_BUCKET_NAME'),
-            Key: `converted/${albumId}/${parseInt(songIndex, 10) + 1}/playlist.m3u8`, // 일단 songIndex 경로로 가져옴
+            Key: `converted/${albumId}/${parseInt(songIndex, 10)}/playlist.m3u8`, // 일단 songIndex 경로로 가져옴
           })
           .promise();
 
@@ -89,7 +89,7 @@ export class MusicService {
         const s3Response = await this.s3
           .getObject({
             Bucket: this.configService.get('S3_BUCKET_NAME'),
-            Key: `converted/${albumId}/${parseInt(songIndex, 10) + 1}/playlist${segmentId}.ts`, // 폴더 구조 동기화 필요
+            Key: `converted/${albumId}/${parseInt(songIndex, 10)}/playlist${segmentId}.ts`, // 폴더 구조 동기화 필요
           })
           .promise();
 

--- a/server/src/music/parser/m3u8-parser.ts
+++ b/server/src/music/parser/m3u8-parser.ts
@@ -2,27 +2,42 @@ import { Injectable } from '@nestjs/common';
 
 @Injectable()
 export class M3U8Parser {
-  parse(content: string, skipSegments: number): string {
+  parse(
+    content: string,
+    skipSegments: number,
+    albumId: string,
+    songIndex: string,
+  ): string {
     const lines = content.split('\n');
     let segmentCount = 0;
-    
-    return lines
-      .map(line => {
-        if (!line) return null;
-        
-        if (line.startsWith('#EXT-X-MEDIA-SEQUENCE')) {
-          return `#EXT-X-MEDIA-SEQUENCE:${skipSegments}`;
-        }
 
-        if (line.startsWith('#EXTINF') || (!line.startsWith('#') && line)) {
-          const shouldInclude = segmentCount >= skipSegments;
-          if (!line.startsWith('#')) segmentCount++;
-          return shouldInclude ? line : null;
-        }
+    return (
+      lines
+        .map((line) => {
+          if (!line) return null;
 
-        return line;
-      })
-      .filter((line): line is string => line !== null)
-      .join('\n') + '\n';
+          if (line.startsWith('#EXT-X-MEDIA-SEQUENCE')) {
+            return `#EXT-X-MEDIA-SEQUENCE:${skipSegments}`;
+          }
+
+          if (line.startsWith('#EXTINF') || (!line.startsWith('#') && line)) {
+            const shouldInclude = segmentCount >= skipSegments;
+            if (!line.startsWith('#')) {
+              const segmentNumber = line.match(/playlist(\d+)\.ts/)?.[1];
+              segmentCount++;
+
+              if (shouldInclude && segmentNumber) {
+                return `/api/music/${albumId}/${songIndex}/playlist${segmentNumber}.ts`;
+              }
+              return null;
+            }
+            return shouldInclude ? line : null;
+          }
+
+          return line;
+        })
+        .filter((line): line is string => line !== null)
+        .join('\n') + '\n'
+    );
   }
 }


### PR DESCRIPTION
## 📋개요
사용자 입장 시간 계산 로직을 수정했습니다
## 🕰️예상 리뷰시간
5분
## 📢상세내용
### 기존 방식
**redis 저장**
```
songs: ${musicId} { id: 1, startTime : "123123123", duration: 180 }
```

각 음악마다 레디스에 startTime과 저장되어있기 때문에 음악마다 joinTimeStamp과 비교

### 변경 방식
**redis 저장**
```
KEY: "rooms:{roomId}:session"
HASH Fields:
- releaseTimestamp: 스트리밍 세션 시작 타임 스탬프
- songs: 각 노래들의 duration을 담은 배열 []

rooms:${albumId}:session { releaseTimestamp "123123123"  songs "[97.812563,84.12]" }
```

songs 배열의 각 노래 음악 재생 시간으로 반복을 돌려서,
현재 timestamp가 [음악 시작 시간, 음악 종료 시간] 사이에 위치해 있으면 해당 노래를 index로 두고, 파싱 진행

* * *

현재 redis에 각 곡이 97.812563초, 84.12초로 저장되어 있다고 가정하고, joinTimeStamp와 relaseTimeStamp를 `timeGap`이라 할때
- timeGap = 0 일 경우 (release되자마자 들어옴) 1번 곡 전체를 받아옴
- timeGap = 97일 경우 1번 곡의 2초만 받아옴
- timeGap = 98일 경우 2번 곡 전체를 받아옴
- timeGap = 181일 경우 2번 곡의 2초만 받아옴
- timeGap = 182일 경우 NotFoundError

### m3u8 파싱 후 응답
![image](https://github.com/user-attachments/assets/4f413a75-029d-440e-b797-045a1a2a1b93)

## 💥특이사항
joinTimeStamp가 유효하지 않을 때 일단 예외 처리를 해주었습니다.
```typescript
throw new NotFoundException('No song found for the given timestamp');
```

프론트에서의 요청은 아래와 같습니다.
`http://${base_url}/api/music/${albumId}/playlist.m3u8?joinTimeStamp=${joinTimeStamp}`

close #78 