### PR TITLE
 앨범 및 노래 정보를 기반으로 레디스에 형식에 맞게 데이터를 저장한다

### DIFF
--- a/server/src/admin/admin.controller.ts
+++ b/server/src/admin/admin.controller.ts
@@ -69,15 +69,19 @@ export class AdminController {
     // });
 
     //3. 노래 파일들 처리: 기존 processSongFiles 사용
-    const message = await this.processSongFiles(
+    const processedSongs = await this.processSongFiles(
       files.songs,
       albumData,
       albumId,
     );
-    return message;
 
-    // 4. MySQL DB에 노래 정보 저장
+    // TODO: MySQL에 processedSong에 들어가 있는 정보를 기반으로 DB에 노래 정보 저장
     //return { albumId };
+
+    return {
+      albumId,
+      message: 'Album songs updated to object storage successfully',
+    };
   }
 
   private async processSongFiles(
@@ -87,10 +91,12 @@ export class AdminController {
   ): Promise<any> {
     const tempDir = await this.createTempDirectory(albumId);
 
-    await Promise.all(
+    //Processed song 안에서 노래에 관한 모든 정보를 JSON 형태로 받을 수 있음
+    //TODO: processedSongs를 기반으로 MySQL에 정보 저장
+    const processedSongs = await Promise.all(
       songFiles.map(async (file, index) => {
         const songInfo = albumData.songs[index];
-        await this.musicProcessingService.processUpload(file, tempDir, {
+        return await this.musicProcessingService.processUpload(file, tempDir, {
           albumId,
           ...songInfo,
         });
@@ -99,10 +105,7 @@ export class AdminController {
 
     await fs.rm(tempDir, { recursive: true, force: true });
 
-    return {
-      albumId,
-      message: 'Album songs updated to object storage successfully',
-    };
+    return processedSongs;
   }
 
   private async createTempDirectory(albumId: string): Promise<string> {

--- a/server/src/admin/admin.controller.ts
+++ b/server/src/admin/admin.controller.ts
@@ -6,14 +6,13 @@ import {
   UploadedFiles,
   UseInterceptors,
 } from '@nestjs/common';
-import { REDIS_CLIENT } from '@/common/redis/redis.module';
-import { RedisClientType } from 'redis';
 import { AlbumDto } from './dto/AlbumDto';
 import { FileFieldsInterceptor } from '@nestjs/platform-express';
 import path from 'path';
 import * as fs from 'fs/promises';
 import { MusicProcessingSevice } from '@/music/music.processor';
 import { AdminService } from './admin.service';
+import { AdminRedisRepository } from './admin.redis.repository';
 
 export interface UploadedFiles {
   albumCover?: Express.Multer.File;
@@ -24,9 +23,9 @@ export interface UploadedFiles {
 @Controller('admin')
 export class AdminController {
   constructor(
-    @Inject(REDIS_CLIENT) private readonly redisClient: RedisClientType,
-    @Inject() private readonly musicProcessingService: MusicProcessingSevice,
+    private readonly adminRedisRepository: AdminRedisRepository,
     private readonly adminService: AdminService,
+    @Inject() private readonly musicProcessingService: MusicProcessingSevice,
   ) {}
 
   @Post('album')
@@ -73,6 +72,15 @@ export class AdminController {
       files.songs,
       albumData,
       albumId,
+    );
+
+    const songDurations = processedSongs.map((song) => song.duration);
+    const releaseTimestamp = new Date(albumData.releaseDate).getTime();
+
+    await this.adminRedisRepository.createStreamingSession(
+      albumId,
+      releaseTimestamp,
+      songDurations,
     );
 
     // TODO: MySQL에 processedSong에 들어가 있는 정보를 기반으로 DB에 노래 정보 저장

--- a/server/src/admin/admin.module.ts
+++ b/server/src/admin/admin.module.ts
@@ -3,6 +3,8 @@ import { ConfigModule } from '@nestjs/config';
 import { AdminController } from './admin.controller';
 import { MusicModule } from '@/music/music.module';
 import { AdminService } from './admin.service';
+import { AdminRedisRepository } from './admin.redis.repository';
+import { RedisModule } from '@/common/redis/redis.module';
 
 @Module({
   imports: [
@@ -10,10 +12,11 @@ import { AdminService } from './admin.service';
       isGlobal: true,
       envFilePath: '.env',
     }),
+    RedisModule,
     MusicModule,
   ],
   controllers: [AdminController],
-  providers: [AdminService],
+  providers: [AdminService, AdminRedisRepository],
   exports: [AdminService],
 })
 export class AdminModule {}

--- a/server/src/admin/admin.redis.repository.ts
+++ b/server/src/admin/admin.redis.repository.ts
@@ -1,0 +1,33 @@
+import { REDIS_CLIENT } from '@/common/redis/redis.module';
+import { Inject, Injectable } from '@nestjs/common';
+import { RedisClientType } from 'redis';
+
+export class AdminRedisRepository {
+  constructor(
+    @Inject(REDIS_CLIENT) private readonly redisClient: RedisClientType,
+  ) {}
+
+  private getStreamingSessionKey(albumId: string): string {
+    return `rooms:${albumId}:session`;
+  }
+
+  async createStreamingSession(
+    albumId: string,
+    releaseTimestamp: number,
+    songDurations: number[],
+  ): Promise<void> {
+    const key = this.getStreamingSessionKey(albumId);
+    const multi = this.redisClient.multi();
+
+    multi
+      .hSet(key, 'releaseTimestamp', releaseTimestamp.toString())
+      .hSet(key, 'songs', JSON.stringify(songDurations));
+
+    await multi.exec();
+  }
+
+  async deleteStreamingSession(albumId: string): Promise<void> {
+    const key = this.getStreamingSessionKey(albumId);
+    await this.redisClient.del(key);
+  }
+}

--- a/server/src/admin/dto/AlbumDto.ts
+++ b/server/src/admin/dto/AlbumDto.ts
@@ -1,6 +1,6 @@
 import {
   IsArray,
-  IsDateString,
+  IsISO8601,
   IsNotEmpty,
   IsNumber,
   IsString,
@@ -18,11 +18,8 @@ export class AlbumDto {
   artist: string;
 
   @IsNotEmpty()
-  @IsDateString()
+  @IsISO8601()
   releaseDate: string;
-
-  @IsString()
-  releaseTime?: string;
 
   @IsNotEmpty()
   @IsNumber()

--- a/server/src/admin/dto/SongDto.ts
+++ b/server/src/admin/dto/SongDto.ts
@@ -17,7 +17,7 @@ export class SongDto {
   trackNumber: number;
 
   @IsString()
-  lyrics: string;
+  lyrics?: string;
 
   @IsString()
   composer: string;

--- a/server/src/admin/dto/SongDto.ts
+++ b/server/src/admin/dto/SongDto.ts
@@ -27,4 +27,7 @@ export class SongDto {
 
   @IsString()
   instrument: string;
+
+  @IsString()
+  source: string;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2021",
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "node",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2140,6 +2140,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sec-ant/readable-stream@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@sec-ant/readable-stream@npm:0.4.1"
+  checksum: 10c0/64e9e9cf161e848067a5bf60cdc04d18495dc28bb63a8d9f8993e4dd99b91ad34e4b563c85de17d91ffb177ec17a0664991d2e115f6543e73236a906068987af
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:^0.27.8":
   version: 0.27.8
   resolution: "@sinclair/typebox@npm:0.27.8"
@@ -2587,6 +2594,13 @@ __metadata:
   peerDependencies:
     "@testing-library/dom": ">=7.21.4"
   checksum: 10c0/68a0c2aa28a3c8e6eb05cafee29705438d7d8a9427423ce5064d44f19c29e89b5636de46dd2f28620fb10abba75c67130185bbc3aa23ac1163a227a5f36641e1
+  languageName: node
+  linkType: hard
+
+"@tokenizer/token@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@tokenizer/token@npm:0.3.0"
+  checksum: 10c0/7ab9a822d4b5ff3f5bca7f7d14d46bdd8432528e028db4a52be7fbf90c7f495cc1af1324691dda2813c6af8dc4b8eb29de3107d4508165f9aa5b53e7d501f155
   languageName: node
   linkType: hard
 
@@ -4895,7 +4909,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"content-type@npm:~1.0.4, content-type@npm:~1.0.5":
+"content-type@npm:^1.0.5, content-type@npm:~1.0.4, content-type@npm:~1.0.5":
   version: 1.0.5
   resolution: "content-type@npm:1.0.5"
   checksum: 10c0/b76ebed15c000aee4678c3707e0860cb6abd4e680a598c0a26e17f0bfae723ec9cc2802f0ff1bc6e4d80603719010431d2231018373d4dde10f9ccff9dadf5af
@@ -5078,7 +5092,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:~4.3.1, debug@npm:~4.3.2, debug@npm:~4.3.4":
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.3.7, debug@npm:~4.3.1, debug@npm:~4.3.2, debug@npm:~4.3.4":
   version: 4.3.7
   resolution: "debug@npm:4.3.7"
   dependencies:
@@ -6463,6 +6477,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"file-type@npm:^19.6.0":
+  version: 19.6.0
+  resolution: "file-type@npm:19.6.0"
+  dependencies:
+    get-stream: "npm:^9.0.1"
+    strtok3: "npm:^9.0.1"
+    token-types: "npm:^6.0.0"
+    uint8array-extras: "npm:^1.3.0"
+  checksum: 10c0/ae90ab618d0e759f26806024eb25ade851406301d2deae4b2dca6e9df0de13b4be575114a5f8129e73f6de537644a45fc4eb7cfa8b7dad63316b01b0e6f3bd2e
+  languageName: node
+  linkType: hard
+
 "filelist@npm:^1.0.4":
   version: 1.0.4
   resolution: "filelist@npm:1.0.4"
@@ -6754,6 +6780,16 @@ __metadata:
   version: 6.0.1
   resolution: "get-stream@npm:6.0.1"
   checksum: 10c0/49825d57d3fd6964228e6200a58169464b8e8970489b3acdc24906c782fb7f01f9f56f8e6653c4a50713771d6658f7cfe051e5eb8c12e334138c9c918b296341
+  languageName: node
+  linkType: hard
+
+"get-stream@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "get-stream@npm:9.0.1"
+  dependencies:
+    "@sec-ant/readable-stream": "npm:^0.4.1"
+    is-stream: "npm:^4.0.1"
+  checksum: 10c0/d70e73857f2eea1826ac570c3a912757dcfbe8a718a033fa0c23e12ac8e7d633195b01710e0559af574cbb5af101009b42df7b6f6b29ceec8dbdf7291931b948
   languageName: node
   linkType: hard
 
@@ -7536,6 +7572,13 @@ __metadata:
   version: 2.0.1
   resolution: "is-stream@npm:2.0.1"
   checksum: 10c0/7c284241313fc6efc329b8d7f08e16c0efeb6baab1b4cd0ba579eb78e5af1aa5da11e68559896a2067cd6c526bd29241dda4eb1225e627d5aa1a89a76d4635a5
+  languageName: node
+  linkType: hard
+
+"is-stream@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "is-stream@npm:4.0.1"
+  checksum: 10c0/2706c7f19b851327ba374687bc4a3940805e14ca496dc672b9629e744d143b1ad9c6f1b162dece81c7bfbc0f83b32b61ccc19ad2e05aad2dd7af347408f60c7f
   languageName: node
   linkType: hard
 
@@ -8686,6 +8729,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"media-typer@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "media-typer@npm:1.1.0"
+  checksum: 10c0/7b4baa40b25964bb90e2121ee489ec38642127e48d0cc2b6baa442688d3fde6262bfdca86d6bbf6ba708784afcac168c06840c71facac70e390f5f759ac121b9
+  languageName: node
+  linkType: hard
+
 "memfs@npm:^3.4.1":
   version: 3.5.3
   resolution: "memfs@npm:3.5.3"
@@ -9522,6 +9572,13 @@ __metadata:
   version: 2.0.0
   resolution: "pathval@npm:2.0.0"
   checksum: 10c0/602e4ee347fba8a599115af2ccd8179836a63c925c23e04bd056d0674a64b39e3a081b643cc7bc0b84390517df2d800a46fcc5598d42c155fe4977095c2f77c5
+  languageName: node
+  linkType: hard
+
+"peek-readable@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "peek-readable@npm:5.3.1"
+  checksum: 10c0/49f628e4728887230c158699e422ebb10747f5e02aee930ec10634fa7142e74e67d3fb3a780e7a9b9f092c61bf185f07d167c099b2359b22a58cee3dbfe0e43b
   languageName: node
   linkType: hard
 
@@ -11133,6 +11190,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strtok3@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "strtok3@npm:9.0.1"
+  dependencies:
+    "@tokenizer/token": "npm:^0.3.0"
+    peek-readable: "npm:^5.3.1"
+  checksum: 10c0/ab96030c3d30899fc885ed87b305086b6421d64c1a2b9f5240c6ecffde7b819e174d67bd3b1ecc14a10f539c7a818a0ac47386b4bbb2fa913f673b6ed1c0eb78
+  languageName: node
+  linkType: hard
+
 "sucrase@npm:^3.32.0":
   version: 3.35.0
   resolution: "sucrase@npm:3.35.0"
@@ -11411,6 +11478,16 @@ __metadata:
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
   checksum: 10c0/93937279934bd66cc3270016dd8d0afec14fb7c94a05c72dc57321f8bd1fa97e5bea6d1f7c89e728d077ca31ea125b78320a616a6c6cd0e6b9cb94cb864381c1
+  languageName: node
+  linkType: hard
+
+"token-types@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "token-types@npm:6.0.0"
+  dependencies:
+    "@tokenizer/token": "npm:^0.3.0"
+    ieee754: "npm:^1.2.1"
+  checksum: 10c0/5bf5eba51d63f71f301659ff70ce10ca43e7038364883437d8b4541cc98377e3e56109b11720e25fe51047014efaccdff90eaf6de9a78270483578814b838ab9
   languageName: node
   linkType: hard
 
@@ -11812,6 +11889,13 @@ __metadata:
   dependencies:
     "@lukeed/csprng": "npm:^1.0.0"
   checksum: 10c0/e9d02d0562c74e74b5a2519e586db9d7f8204978e476cddd191ee1a9efb85efafdbab2dbf3fc3dde0f5da01fd9da161f37d604dabf513447fd2c03d008f1324c
+  languageName: node
+  linkType: hard
+
+"uint8array-extras@npm:^1.3.0, uint8array-extras@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "uint8array-extras@npm:1.4.0"
+  checksum: 10c0/eaffd3388634b7e5e1496073b878dd19136043137d3e7e0d2a453e37f566a5a551e640819e1a6596c6df9b9d1f7b70884cc29db6a357bdd424811f3598d504dd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 📋개요

- 서버 내에서 지정한 Dto를 기반으로 효율적으로 데이터를 레디스에 저장할 것을 기대
- 앨범 시작 시간으로 timestamp 형식으로 저장
- 각 노래에 관한 duration을 저장 (배열을 JSON 형식으로 저장)

## 🕰️예상 리뷰시간

최대 5분정도

## 📢상세내용

- MySQL repository 레이어와 구분짓기 위하여 `admin.redis.repository.ts`에서 구현 진행
- redis에 저장되어있는 키 형식: `room:{roomId}:session`
- Hash 구조
```
KEY: "rooms:{roomId}:session"
HASH Fields:
- releaseTimestamp: 스트리밍 세션 시작 타임 스탬프
- songs: 각 노래들의 duration을 담은 배열 []
```
<img width="424" alt="Screenshot 2024-11-20 at 4 40 05 PM" src="https://github.com/user-attachments/assets/2b627711-8c58-49cb-935f-6a6327186efa">


## 💥특이사항