### PR TITLE
스트리밍 페이지 접근 시 관련 데이터를 반환하는 API 구현

### DIFF
--- a/server/src/album/album.entity.ts
+++ b/server/src/album/album.entity.ts
@@ -15,7 +15,12 @@ export class Album {
   @Column({ type: 'varchar', length: 30 })
   tags: string;
 
-  @Column({ name: 'release_date', type: 'char', length: 16, nullable: false })
+  @Column({
+    name: 'release_date',
+    type: 'char',
+    length: 19,
+    nullable: false,
+  })
   releaseDate: string;
 
   @Column({ name: 'banner_url', type: 'varchar', length: 500 })

--- a/server/src/album/albumResponse.dto.ts
+++ b/server/src/album/albumResponse.dto.ts
@@ -1,0 +1,24 @@
+import { Expose } from 'class-transformer';
+
+export class AlbumResponseDto {
+  @Expose()
+  id: string;
+
+  @Expose()
+  title: string;
+
+  @Expose()
+  artist: string;
+
+  @Expose()
+  tags: string;
+
+  @Expose()
+  releaseDate: string;
+
+  @Expose()
+  bannerUrl: string;
+
+  @Expose()
+  jacketUrl: string;
+}

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -15,6 +15,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Album } from '@/album/album.entity';
 import { Song } from '@/song/song.entity';
 import { SongModule } from '@/song/song.module';
+import { MusicRepository } from '@/music/music.repository';
 
 @Module({
   imports: [
@@ -38,6 +39,6 @@ import { SongModule } from '@/song/song.module';
     TypeOrmModule.forFeature([Song, Album]),
   ],
   controllers: [AppController, RoomController],
-  providers: [Logger, AppService, RoomRepository, RoomGateway],
+  providers: [Logger, AppService, RoomRepository, RoomGateway, MusicRepository],
 })
 export class AppModule {}

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -35,6 +35,7 @@ import { SongModule } from '@/song/song.module';
       database: process.env.DB_DATABASE,
       entities: [Album, Song],
     }),
+    TypeOrmModule.forFeature([Song, Album]),
   ],
   controllers: [AppController, RoomController],
   providers: [Logger, AppService, RoomRepository, RoomGateway],

--- a/server/src/room/room.controller.ts
+++ b/server/src/room/room.controller.ts
@@ -73,7 +73,11 @@ export class RoomController {
         songList.map(async (song) => await this.getSongResponseDto(song)),
       );
 
-      const totalDuration = songResponseList.reduce((acc, song) => {
+      const sortedSongList = songResponseList.sort(
+        (a, b) => a.trackNumber - b.trackNumber,
+      );
+
+      const totalDuration = sortedSongList.reduce((acc, song) => {
         return acc + parseInt(song.duration);
       }, 0);
 
@@ -86,7 +90,7 @@ export class RoomController {
         success: true,
         ...roomInfo,
         albumResponse,
-        songResponseList,
+        sortedSongList,
         totalDuration,
         trackOrder: trackInfo.id,
       };

--- a/server/src/room/room.controller.ts
+++ b/server/src/room/room.controller.ts
@@ -68,16 +68,15 @@ export class RoomController {
         where: { id: roomId },
       });
       const albumResponse = await this.getAlbumResponseDto(albumInfo);
-      const songList = await this.songRepository.findBy({ albumId: roomId });
+      const songList = await this.songRepository.find({
+        where: { albumId: roomId },
+        order: { trackNumber: 'ASC' },
+      });
       const songResponseList = await Promise.all(
         songList.map(async (song) => await this.getSongResponseDto(song)),
       );
 
-      const sortedSongList = songResponseList.sort(
-        (a, b) => a.trackNumber - b.trackNumber,
-      );
-
-      const totalDuration = sortedSongList.reduce((acc, song) => {
+      const totalDuration = songResponseList.reduce((acc, song) => {
         return acc + parseInt(song.duration);
       }, 0);
 
@@ -90,7 +89,7 @@ export class RoomController {
         success: true,
         ...roomInfo,
         albumResponse,
-        sortedSongList,
+        songResponseList,
         totalDuration,
         trackOrder: trackInfo.id,
       };

--- a/server/src/room/room.controller.ts
+++ b/server/src/room/room.controller.ts
@@ -20,7 +20,8 @@ import { Repository } from 'typeorm';
 import { Song } from '@/song/song.entity';
 import { AlbumResponseDto } from '@/album/albumResponse.dto';
 import { SongResponseDto } from '@/song/songResponse.dto';
-import { plainToClass, plainToInstance } from 'class-transformer';
+import { plainToInstance } from 'class-transformer';
+import { MusicRepository } from '@/music/music.repository';
 
 @ApiTags('기본')
 @Controller('room')
@@ -32,6 +33,7 @@ export class RoomController {
     private readonly albumRepository: Repository<Album>,
     @InjectRepository(Song)
     private readonly songRepository: Repository<Song>,
+    private readonly musicRepository: MusicRepository,
   ) {}
 
   @ApiOperation({ summary: '방 생성' })
@@ -75,12 +77,18 @@ export class RoomController {
         return acc + parseInt(song.duration);
       }, 0);
 
+      const trackInfo = await this.musicRepository.findSongByJoinTimestamp(
+        roomId,
+        Date.now(),
+      );
+
       return {
         success: true,
         ...roomInfo,
         albumResponse,
         songResponseList,
         totalDuration,
+        trackOrder: trackInfo.id,
       };
     } catch (e) {
       return { success: false, error: e.message };

--- a/server/src/song/song.entity.ts
+++ b/server/src/song/song.entity.ts
@@ -11,35 +11,38 @@ import { Album } from '@/album/album.entity';
 @Entity()
 export class Song {
   @PrimaryGeneratedColumn()
-  private id: number;
+  id: number;
+
+  @Column({ name: 'album_id', type: 'char', length: 36 })
+  albumId: string;
 
   @ManyToOne(() => Album, { nullable: false })
   @JoinColumn({ name: 'album_id' })
-  private albumId: string;
+  album: Album;
 
   @Column({ type: 'varchar', length: 50, nullable: false })
-  private title: string;
+  title: string;
 
   @Column({ name: 'track_number', type: 'int', nullable: false })
-  private trackNumber!: number;
+  trackNumber: number;
 
   @Column({ type: 'text' })
-  private lyrics: string;
+  lyrics: string;
 
   @Column({ type: 'varchar', length: 200, nullable: false })
-  private composer!: string;
+  composer: string;
 
   @Column({ type: 'varchar', length: 200, nullable: false })
-  private writer: string;
+  writer: string;
 
   @Column({ type: 'varchar', length: 200, nullable: false })
-  private instrument!: string;
+  instrument: string;
 
   @Column({ name: 'sources', type: 'varchar', length: 50 })
-  private source: string;
+  source: string;
 
   @Column({ type: 'int', nullable: false })
-  private duration: number;
+  duration: number;
 
   constructor(songDto?: SongSaveDto) {
     if (!songDto) return;
@@ -47,10 +50,10 @@ export class Song {
     this.title = songDto.title;
     this.trackNumber = songDto.trackNumber;
     this.lyrics = songDto.lyrics;
-    this.composer! = songDto.composer;
-    this.writer! = songDto.writer;
-    this.instrument! = songDto.instrument;
+    this.composer = songDto.composer;
+    this.writer = songDto.writer;
+    this.instrument = songDto.instrument;
     this.source = songDto.source;
-    this.duration! = songDto.duration;
+    this.duration = songDto.duration;
   }
 }

--- a/server/src/song/songResponse.dto.ts
+++ b/server/src/song/songResponse.dto.ts
@@ -16,7 +16,7 @@ export class SongResponseDto {
 
   @Expose()
   @IsNumber()
-  trackNumber: string;
+  trackNumber: number;
 
   @Expose()
   lyrics: string;

--- a/server/src/song/songResponse.dto.ts
+++ b/server/src/song/songResponse.dto.ts
@@ -1,0 +1,42 @@
+import { Expose } from 'class-transformer';
+import { IsNumber, IsString } from 'class-validator';
+
+export class SongResponseDto {
+  @Expose()
+  @IsNumber()
+  id: number;
+
+  @Expose()
+  @IsString()
+  albumId: string;
+
+  @Expose()
+  @IsString()
+  title: string;
+
+  @Expose()
+  @IsNumber()
+  trackNumber: string;
+
+  @Expose()
+  lyrics: string;
+
+  @Expose()
+  @IsString()
+  composer: string;
+
+  @Expose()
+  @IsString()
+  writer: string;
+
+  @Expose()
+  @IsString()
+  instrument: string;
+
+  @Expose()
+  source: string;
+
+  @Expose()
+  @IsString()
+  duration: string;
+}


### PR DESCRIPTION
close #54 

## 📋개요

스트리밍 페이지에 사용자가 접근했을 때, 화면에 출력하기 위한 앨범명, 태그, 앨범 자켓 url 등 필요한 데이터를 반환하는 API를 구현했습니다.

## 🕰️예상 리뷰시간

7분

## 📢상세내용

- 방 참여 가능 인원 증설 10 -> 999
- 방 id를 통해 해당 id의 Album과 Song들을 SQL에서 가져오는 로직
- 소켓의 join room 로직을 handleConnection으로 이동
- 소켓의 leave room 로직을 handleDisconnect로 이동

![image](https://github.com/user-attachments/assets/c159bfcd-4662-4404-95da-5a5d23ddb251)

