### PR TITLE
방 생성 로직 및 레이어 개선

### DIFF
--- a/server/src/admin/admin.controller.ts
+++ b/server/src/admin/admin.controller.ts
@@ -14,9 +14,6 @@ import { MusicProcessingSevice } from '@/music/music.processor';
 import { AdminService } from './admin.service';
 import { AdminRedisRepository } from './admin.redis.repository';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Song } from '@/song/song.entity';
-import { Repository } from 'typeorm';
-import { SongSaveDto } from '@/song/songSave.dto';
 import { Album } from '@/album/album.entity';
 import { RoomRepository } from '@/room/room.repository';
 import { Room } from '@/room/room.entity';
@@ -34,7 +31,6 @@ export class AdminController {
     private readonly adminRedisRepository: AdminRedisRepository,
     private readonly adminService: AdminService,
     @Inject() private readonly musicProcessingService: MusicProcessingSevice,
-    @InjectRepository(Song) private readonly songRepository: Repository<Song>,
     @InjectRepository(Album)
     private readonly albumRepository: AlbumRepository,
     private readonly roomRepository: RoomRepository,
@@ -84,11 +80,7 @@ export class AdminController {
       songDurations,
     );
 
-    // TODO: MySQL에 processedSong에 들어가 있는 정보를 기반으로 DB에 노래 정보 저장
-    processedSongs.forEach((song) => {
-      const songDto = new SongSaveDto({ ...song, albumId: album.getId() });
-      this.songRepository.save(new Song(songDto));
-    });
+    await this.adminService.saveSongs(processedSongs, album.id);
 
     await this.roomRepository.createRoom(
       new Room({ id: album.getId(), createdAt: new Date() }),

--- a/server/src/admin/admin.controller.ts
+++ b/server/src/admin/admin.controller.ts
@@ -20,6 +20,7 @@ import { SongSaveDto } from '@/song/songSave.dto';
 import { Album } from '@/album/album.entity';
 import { RoomRepository } from '@/room/room.repository';
 import { Room } from '@/room/room.entity';
+import { AlbumRepository } from '@/album/album.repository';
 
 export interface UploadedFiles {
   albumCover?: Express.Multer.File;
@@ -35,7 +36,7 @@ export class AdminController {
     @Inject() private readonly musicProcessingService: MusicProcessingSevice,
     @InjectRepository(Song) private readonly songRepository: Repository<Song>,
     @InjectRepository(Album)
-    private readonly albumRepository: Repository<Album>,
+    private readonly albumRepository: AlbumRepository,
     private readonly roomRepository: RoomRepository,
   ) {}
 

--- a/server/src/admin/admin.controller.ts
+++ b/server/src/admin/admin.controller.ts
@@ -78,7 +78,6 @@ export class AdminController {
     const tempDir = await this.createTempDirectory(albumId);
 
     //Processed song 안에서 노래에 관한 모든 정보를 JSON 형태로 받을 수 있음
-    //TODO: processedSongs를 기반으로 MySQL에 정보 저장
     const processedSongs = await Promise.all(
       songFiles.map(async (file, index) => {
         const songInfo = albumData.songs[index];

--- a/server/src/admin/admin.controller.ts
+++ b/server/src/admin/admin.controller.ts
@@ -11,7 +11,6 @@ import path from 'path';
 import * as fs from 'fs/promises';
 import { MusicProcessingSevice } from '@/music/music.processor';
 import { AdminService } from './admin.service';
-import { InjectRepository } from '@nestjs/typeorm';
 import { Album } from '@/album/album.entity';
 import { AlbumRepository } from '@/album/album.repository';
 import { RoomService } from '@/room/room.service';
@@ -27,7 +26,6 @@ export class AdminController {
   constructor(
     private readonly adminService: AdminService,
     private readonly musicProcessingService: MusicProcessingSevice,
-    @InjectRepository(Album)
     private readonly albumRepository: AlbumRepository,
     private readonly roomService: RoomService,
   ) {}

--- a/server/src/admin/admin.controller.ts
+++ b/server/src/admin/admin.controller.ts
@@ -13,9 +13,8 @@ import { MusicProcessingSevice } from '@/music/music.processor';
 import { AdminService } from './admin.service';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Album } from '@/album/album.entity';
-import { RoomRepository } from '@/room/room.repository';
-import { Room } from '@/room/room.entity';
 import { AlbumRepository } from '@/album/album.repository';
+import { RoomService } from '@/room/room.service';
 
 export interface UploadedFiles {
   albumCover?: Express.Multer.File;
@@ -30,7 +29,7 @@ export class AdminController {
     private readonly musicProcessingService: MusicProcessingSevice,
     @InjectRepository(Album)
     private readonly albumRepository: AlbumRepository,
-    private readonly roomRepository: RoomRepository,
+    private readonly roomService: RoomService,
   ) {}
 
   @Post('album')
@@ -60,9 +59,7 @@ export class AdminController {
 
     await this.adminService.initializeStreamingSession(processedSongs, album);
     await this.adminService.saveSongs(processedSongs, album.id);
-    await this.roomRepository.createRoom(
-      new Room({ id: album.getId(), createdAt: new Date() }),
-    );
+    await this.roomService.initializeRoom(album.id);
 
     return {
       albumId: album.id,

--- a/server/src/admin/admin.controller.ts
+++ b/server/src/admin/admin.controller.ts
@@ -51,18 +51,8 @@ export class AdminController {
     const albumData = JSON.parse(albumDataString) as AlbumDto;
     const album = await this.albumRepository.save(new Album(albumData));
 
-    // 앨범 임시 ID
-    const imageUrls: {
-      albumCoverURL?: string;
-      bannerCoverURL?: string;
-    } = await this.adminService.uploadImageFiles(
-      files.albumCover?.[0],
-      files.bannerCover?.[0],
-      `converted/${album.id}`,
-    );
-
-    await this.albumRepository.updateAlbumUrls(album.id, imageUrls);
-    // TODO: albumData.setBannerUrl(albumCoverUrl), albumData.setJacketUrl(bannerCoverUrl);
+    // 앨범 이미지 업로드 및 DB 저장
+    await this.adminService.saveAlbumCoverAndBanner(files, album.id);
 
     //3. 노래 파일들 처리: 기존 processSongFiles 사용
     const processedSongs = await this.processSongFiles(

--- a/server/src/admin/admin.controller.ts
+++ b/server/src/admin/admin.controller.ts
@@ -59,16 +59,11 @@ export class AdminController {
     const imageUrls: {
       albumCoverURL?: string;
       bannerCoverURL?: string;
-    } = {};
-
-    //2. 앨범 커버 이미지, 배너 이미지를 S3에 업로드 하고 URL을 반환 받음
-    const uploadResults = await this.adminService.uploadImageFiles(
+    } = await this.adminService.uploadImageFiles(
       files.albumCover?.[0],
       files.bannerCover?.[0],
       `converted/${album.id}`,
     );
-
-    Object.assign(imageUrls, uploadResults);
 
     await this.albumRepository.updateAlbumUrls(album.id, imageUrls);
     // TODO: albumData.setBannerUrl(albumCoverUrl), albumData.setJacketUrl(bannerCoverUrl);

--- a/server/src/admin/admin.controller.ts
+++ b/server/src/admin/admin.controller.ts
@@ -1,7 +1,6 @@
 import {
   Body,
   Controller,
-  Inject,
   Post,
   UploadedFiles,
   UseInterceptors,
@@ -28,7 +27,7 @@ export interface UploadedFiles {
 export class AdminController {
   constructor(
     private readonly adminService: AdminService,
-    @Inject() private readonly musicProcessingService: MusicProcessingSevice,
+    private readonly musicProcessingService: MusicProcessingSevice,
     @InjectRepository(Album)
     private readonly albumRepository: AlbumRepository,
     private readonly roomRepository: RoomRepository,

--- a/server/src/admin/admin.controller.ts
+++ b/server/src/admin/admin.controller.ts
@@ -62,20 +62,15 @@ export class AdminController {
     } = {};
 
     //2. 앨범 커버 이미지, 배너 이미지를 S3에 업로드 하고 URL을 반환 받음
-    if (files.albumCover?.[0] || files.bannerCover?.[0]) {
-      const uploadResults = await this.adminService.uploadImageFiles(
-        files.albumCover?.[0],
-        files.bannerCover?.[0],
-        `converted/${album.id}`,
-      );
+    const uploadResults = await this.adminService.uploadImageFiles(
+      files.albumCover?.[0],
+      files.bannerCover?.[0],
+      `converted/${album.id}`,
+    );
 
-      Object.assign(imageUrls, uploadResults);
-    }
+    Object.assign(imageUrls, uploadResults);
 
-    // await this.adminRepository.updateAlbumUrls(albumId, {
-    //   albumCoverURL,
-    //   bannerCoverURL
-    // });
+    await this.albumRepository.updateAlbumUrls(album.id, imageUrls);
     // TODO: albumData.setBannerUrl(albumCoverUrl), albumData.setJacketUrl(bannerCoverUrl);
 
     //3. 노래 파일들 처리: 기존 processSongFiles 사용

--- a/server/src/admin/admin.controller.ts
+++ b/server/src/admin/admin.controller.ts
@@ -18,6 +18,8 @@ import { Song } from '@/song/song.entity';
 import { Repository } from 'typeorm';
 import { SongSaveDto } from '@/song/songSave.dto';
 import { Album } from '@/album/album.entity';
+import { RoomRepository } from '@/room/room.repository';
+import { Room } from '@/room/room.entity';
 
 export interface UploadedFiles {
   albumCover?: Express.Multer.File;
@@ -34,6 +36,7 @@ export class AdminController {
     @InjectRepository(Song) private readonly songRepository: Repository<Song>,
     @InjectRepository(Album)
     private readonly albumRepository: Repository<Album>,
+    private readonly roomRepository: RoomRepository,
   ) {}
 
   @Post('album')
@@ -99,6 +102,11 @@ export class AdminController {
       const songDto = new SongSaveDto({ ...song, albumId: album.getId() });
       this.songRepository.save(new Song(songDto));
     });
+
+    await this.roomRepository.createRoom(
+      new Room({ id: album.getId(), createdAt: new Date() }),
+    );
+
     return {
       albumId,
       message: 'Album songs updated to object storage successfully',

--- a/server/src/admin/admin.module.ts
+++ b/server/src/admin/admin.module.ts
@@ -9,6 +9,8 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Song } from '@/song/song.entity';
 import { Album } from '@/album/album.entity';
 import { RoomModule } from '@/room/room.module';
+import { AlbumModule } from '@/album/album.module';
+import { SongModule } from '@/song/song.module';
 
 @Module({
   imports: [
@@ -16,9 +18,11 @@ import { RoomModule } from '@/room/room.module';
       isGlobal: true,
       envFilePath: '.env',
     }),
+    AlbumModule,
     RedisModule,
     MusicModule,
     RoomModule,
+    SongModule,
     TypeOrmModule.forFeature([Album, Song]),
   ],
   controllers: [AdminController],

--- a/server/src/admin/admin.module.ts
+++ b/server/src/admin/admin.module.ts
@@ -8,6 +8,7 @@ import { RedisModule } from '@/common/redis/redis.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Song } from '@/song/song.entity';
 import { Album } from '@/album/album.entity';
+import { RoomModule } from '@/room/room.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { Album } from '@/album/album.entity';
     }),
     RedisModule,
     MusicModule,
+    RoomModule,
     TypeOrmModule.forFeature([Album, Song]),
   ],
   controllers: [AdminController],

--- a/server/src/admin/admin.service.ts
+++ b/server/src/admin/admin.service.ts
@@ -21,7 +21,10 @@ export class AdminService {
     albumCoverFile: Express.Multer.File,
     bannerCoverFile: Express.Multer.File,
     prefix: string,
-  ) {
+  ): Promise<{
+    albumCoverURL?: string;
+    bannerCoverURL?: string;
+  }> {
     const results: {
       albumCoverURL?: string;
       bannerCoverURL?: string;

--- a/server/src/admin/admin.service.ts
+++ b/server/src/admin/admin.service.ts
@@ -1,12 +1,18 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as AWS from 'aws-sdk';
+import { Song } from '@/song/song.entity';
+import { SongSaveDto } from '@/song/songSave.dto';
+import { SongRepository } from '@/song/song.repository';
 
 @Injectable()
 export class AdminService {
   private s3;
 
-  constructor(private configService: ConfigService) {
+  constructor(
+    private configService: ConfigService,
+    private readonly songRepository: SongRepository,
+  ) {
     this.s3 = new AWS.S3({
       endpoint: new AWS.Endpoint('https://kr.object.ncloudstorage.com'),
       region: 'kr-standard',
@@ -72,5 +78,12 @@ export class AdminService {
     } catch (error) {
       throw new Error(`Failed to upload file to S3: ${error.message}`);
     }
+  }
+
+  async saveSongs(songs: Song[], albumId: string) {
+    songs.forEach((song) => {
+      const songDto = new SongSaveDto({ ...song, albumId: albumId });
+      this.songRepository.save(new Song(songDto));
+    });
   }
 }

--- a/server/src/admin/admin.service.ts
+++ b/server/src/admin/admin.service.ts
@@ -6,7 +6,6 @@ import { SongSaveDto } from '@/song/songSave.dto';
 import { SongRepository } from '@/song/song.repository';
 import { AlbumRepository } from '@/album/album.repository';
 import { UploadedFiles } from '@/admin/admin.controller';
-import { InjectRepository } from '@nestjs/typeorm';
 import { Album } from '@/album/album.entity';
 import { AdminRedisRepository } from '@/admin/admin.redis.repository';
 
@@ -16,9 +15,7 @@ export class AdminService {
 
   constructor(
     private configService: ConfigService,
-    @InjectRepository(Song)
     private readonly songRepository: SongRepository,
-    @InjectRepository(Album)
     private readonly albumRepository: AlbumRepository,
     private readonly adminRedisRepository: AdminRedisRepository,
   ) {

--- a/server/src/album/album.module.ts
+++ b/server/src/album/album.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Album } from '@/album/album.entity';
+import { AlbumRepository } from '@/album/album.repository';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Album])],
   controllers: [],
-  providers: [],
-  exports: [],
+  providers: [AlbumRepository],
+  exports: [AlbumRepository],
 })
 export class AlbumModule {}

--- a/server/src/album/album.module.ts
+++ b/server/src/album/album.module.ts
@@ -7,6 +7,6 @@ import { AlbumRepository } from '@/album/album.repository';
   imports: [TypeOrmModule.forFeature([Album])],
   controllers: [],
   providers: [AlbumRepository],
-  exports: [AlbumRepository, TypeOrmModule],
+  exports: [AlbumRepository],
 })
 export class AlbumModule {}

--- a/server/src/album/album.module.ts
+++ b/server/src/album/album.module.ts
@@ -7,6 +7,6 @@ import { AlbumRepository } from '@/album/album.repository';
   imports: [TypeOrmModule.forFeature([Album])],
   controllers: [],
   providers: [AlbumRepository],
-  exports: [AlbumRepository],
+  exports: [AlbumRepository, TypeOrmModule],
 })
 export class AlbumModule {}

--- a/server/src/album/album.repository.ts
+++ b/server/src/album/album.repository.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Album } from '@/album/album.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class AlbumRepository {
+  constructor(
+    @InjectRepository(Album)
+    private readonly repository: Repository<Album>,
+  ) {}
+
+  async updateAlbumUrls(
+    albumId: string,
+    urls: { albumCoverURL?: string; bannerCoverURL?: string },
+  ): Promise<void> {
+    await this.repository
+      .createQueryBuilder()
+      .update(Album)
+      .set({ bannerUrl: urls.bannerCoverURL, jacketUrl: urls.albumCoverURL })
+      .where('id = :albumId', { albumId })
+      .execute();
+  }
+
+  async save(album: Album) {
+    return await this.repository.save(album);
+  }
+
+  async findById(roomId: string) {
+    return this.repository.findOne({
+      where: { id: roomId },
+    });
+  }
+}

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -38,7 +38,6 @@ import { RoomModule } from '@/room/room.module';
       database: process.env.DB_DATABASE,
       entities: [Album, Song],
     }),
-    TypeOrmModule.forFeature([Song, Album]),
   ],
   controllers: [AppController],
   providers: [Logger, AppService, MusicRepository],

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -16,6 +16,7 @@ import { Album } from '@/album/album.entity';
 import { Song } from '@/song/song.entity';
 import { SongModule } from '@/song/song.module';
 import { MusicRepository } from '@/music/music.repository';
+import { RoomModule } from '@/room/room.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { MusicRepository } from '@/music/music.repository';
     EmojiModule,
     AlbumModule,
     SongModule,
+    RoomModule,
     TypeOrmModule.forRoot({
       type: 'mysql',
       host: process.env.DB_HOST,
@@ -38,7 +40,7 @@ import { MusicRepository } from '@/music/music.repository';
     }),
     TypeOrmModule.forFeature([Song, Album]),
   ],
-  controllers: [AppController, RoomController],
-  providers: [Logger, AppService, RoomRepository, RoomGateway, MusicRepository],
+  controllers: [AppController],
+  providers: [Logger, AppService, MusicRepository],
 })
 export class AppModule {}

--- a/server/src/common/constants/repository.constant.ts
+++ b/server/src/common/constants/repository.constant.ts
@@ -1,0 +1,4 @@
+export const ORDER = {
+  ASC: 'ASC',
+  DESC: 'DESC',
+} as const;

--- a/server/src/music/music.module.ts
+++ b/server/src/music/music.module.ts
@@ -28,6 +28,6 @@ import { S3CacheService } from '../common/s3Cache/s3Cache.service';
     M3U8Parser,
     S3CacheService,
   ],
-  exports: [MusicProcessingSevice],
+  exports: [MusicProcessingSevice, MusicRepository],
 })
 export class MusicModule {}

--- a/server/src/room/room.constant.ts
+++ b/server/src/room/room.constant.ts
@@ -1,0 +1,4 @@
+export const ROOM_STATUS = {
+  ACTIVE: 'active',
+  INACTIVE: 'inactive',
+} as const;

--- a/server/src/room/room.controller.ts
+++ b/server/src/room/room.controller.ts
@@ -45,7 +45,7 @@ export class RoomController {
       const roomInfo = await this.redisClient.hGetAll(roomKey);
       const albumInfo = await this.albumRepository.findById(roomId);
       const albumResponse = await this.getAlbumResponseDto(albumInfo);
-      const songList = await this.songRepository.findByIdWithOrderByTrackNumber(
+      const songList = await this.songRepository.getAlbumTracksSorted(
         roomId,
         ORDER.ASC,
       );

--- a/server/src/room/room.controller.ts
+++ b/server/src/room/room.controller.ts
@@ -22,6 +22,8 @@ import { AlbumResponseDto } from '@/album/albumResponse.dto';
 import { SongResponseDto } from '@/song/songResponse.dto';
 import { plainToInstance } from 'class-transformer';
 import { MusicRepository } from '@/music/music.repository';
+import { SongRepository } from '@/song/song.repository';
+import { ORDER } from '@/common/constants/repository.constant';
 
 @ApiTags('기본')
 @Controller('room')
@@ -31,8 +33,7 @@ export class RoomController {
     private readonly roomRepository: RoomRepository,
     @InjectRepository(Album)
     private readonly albumRepository: Repository<Album>,
-    @InjectRepository(Song)
-    private readonly songRepository: Repository<Song>,
+    private readonly songRepository: SongRepository,
     private readonly musicRepository: MusicRepository,
   ) {}
 
@@ -48,10 +49,10 @@ export class RoomController {
         where: { id: roomId },
       });
       const albumResponse = await this.getAlbumResponseDto(albumInfo);
-      const songList = await this.songRepository.find({
-        where: { albumId: roomId },
-        order: { trackNumber: 'ASC' },
-      });
+      const songList = await this.songRepository.findByIdWithOrderByTrackNumber(
+        roomId,
+        ORDER.ASC,
+      );
       const songResponseList = await Promise.all(
         songList.map(async (song) => await this.getSongResponseDto(song)),
       );

--- a/server/src/room/room.controller.ts
+++ b/server/src/room/room.controller.ts
@@ -36,26 +36,6 @@ export class RoomController {
     private readonly musicRepository: MusicRepository,
   ) {}
 
-  @ApiOperation({ summary: '방 생성' })
-  @ApiResponse({ status: 201, description: 'Room created successfully' })
-  @Post()
-  async createRoom(): Promise<any> {
-    try {
-      const roomId = 'TEMP_RANDOM_ROOM_ID';
-      const roomInfo: RoomInfo = {
-        currentUsers: 0,
-        maxCapacity: 999,
-        isActive: true,
-        currentSong: '',
-        songs: ['LOVE SONG', 'POWER'],
-      };
-      // await this.roomRepository.createRoom(roomId, roomInfo);
-      return { success: true, message: 'Room created' };
-    } catch (e) {
-      return { success: false, error: e.message };
-    }
-  }
-
   @ApiOperation({ summary: '방 정보 확인' })
   @ApiParam({ name: 'roomId', required: true })
   @ApiResponse({ status: 200, description: 'Room info retrieved successfully' })

--- a/server/src/room/room.controller.ts
+++ b/server/src/room/room.controller.ts
@@ -24,6 +24,7 @@ import { plainToInstance } from 'class-transformer';
 import { MusicRepository } from '@/music/music.repository';
 import { SongRepository } from '@/song/song.repository';
 import { ORDER } from '@/common/constants/repository.constant';
+import { AlbumRepository } from '@/album/album.repository';
 
 @ApiTags('기본')
 @Controller('room')
@@ -31,8 +32,7 @@ export class RoomController {
   constructor(
     @Inject(REDIS_CLIENT) private readonly redisClient: RedisClientType,
     private readonly roomRepository: RoomRepository,
-    @InjectRepository(Album)
-    private readonly albumRepository: Repository<Album>,
+    private readonly albumRepository: AlbumRepository,
     private readonly songRepository: SongRepository,
     private readonly musicRepository: MusicRepository,
   ) {}
@@ -45,9 +45,7 @@ export class RoomController {
     const roomKey = `rooms:${roomId}`;
     try {
       const roomInfo = await this.redisClient.hGetAll(roomKey);
-      const albumInfo = await this.albumRepository.findOne({
-        where: { id: roomId },
-      });
+      const albumInfo = await this.albumRepository.findById(roomId);
       const albumResponse = await this.getAlbumResponseDto(albumInfo);
       const songList = await this.songRepository.findByIdWithOrderByTrackNumber(
         roomId,

--- a/server/src/room/room.controller.ts
+++ b/server/src/room/room.controller.ts
@@ -8,23 +8,21 @@ import {
   Req,
 } from '@nestjs/common';
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { RoomInfo, RoomRepository } from '@/room/room.repository';
+import { RoomRepository } from '@/room/room.repository';
 import { REDIS_CLIENT } from '@/common/redis/redis.module';
 import { RedisClientType } from 'redis';
 import * as crypto from 'node:crypto';
 import { RandomNameUtil } from '@/common/randomname/random-name.util';
 import { Request } from 'express';
-import { InjectRepository } from '@nestjs/typeorm';
 import { Album } from '@/album/album.entity';
-import { Repository } from 'typeorm';
 import { Song } from '@/song/song.entity';
 import { AlbumResponseDto } from '@/album/albumResponse.dto';
 import { SongResponseDto } from '@/song/songResponse.dto';
 import { plainToInstance } from 'class-transformer';
-import { MusicRepository } from '@/music/music.repository';
 import { SongRepository } from '@/song/song.repository';
 import { ORDER } from '@/common/constants/repository.constant';
 import { AlbumRepository } from '@/album/album.repository';
+import { RoomService } from '@/room/room.service';
 
 @ApiTags('기본')
 @Controller('room')
@@ -34,7 +32,7 @@ export class RoomController {
     private readonly roomRepository: RoomRepository,
     private readonly albumRepository: AlbumRepository,
     private readonly songRepository: SongRepository,
-    private readonly musicRepository: MusicRepository,
+    private readonly roomService: RoomService,
   ) {}
 
   @ApiOperation({ summary: '방 정보 확인' })
@@ -59,10 +57,7 @@ export class RoomController {
         return acc + parseInt(song.duration);
       }, 0);
 
-      const trackInfo = await this.musicRepository.findSongByJoinTimestamp(
-        roomId,
-        1700000000000,
-      );
+      const trackOrder = this.roomService.getTrackOrder(roomId);
 
       return {
         success: true,
@@ -70,7 +65,7 @@ export class RoomController {
         albumResponse,
         songResponseList,
         totalDuration,
-        trackOrder: trackInfo.id,
+        trackOrder,
       };
     } catch (e) {
       return { success: false, error: e.message };

--- a/server/src/room/room.entity.ts
+++ b/server/src/room/room.entity.ts
@@ -1,8 +1,7 @@
 export class Room {
   id: string;
-  hostId: string;
   createdAt: Date;
-  
+
   constructor(partial: Partial<Room>) {
     Object.assign(this, partial);
   }

--- a/server/src/room/room.gateway.ts
+++ b/server/src/room/room.gateway.ts
@@ -10,7 +10,6 @@ import {
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 import { RoomRepository } from './room.repository';
-import { Room } from './room.entity';
 import { RandomNameUtil } from '@/common/randomname/random-name.util';
 
 @WebSocketGateway({

--- a/server/src/room/room.gateway.ts
+++ b/server/src/room/room.gateway.ts
@@ -104,53 +104,6 @@ export class RoomGateway
     }
   }
 
-  @SubscribeMessage('createRoom')
-  async handleCreateRoom(
-    @ConnectedSocket() client: Socket,
-  ): Promise<{ success: boolean; room?: Room; error?: string }> {
-    try {
-      const clientId = client.id;
-      const roomId = await this.roomRepository.generateRoomId();
-
-      if (client.data.name === undefined) {
-        client.data.name = RandomNameUtil.generate();
-      }
-      const room = new Room({
-        id: roomId,
-        hostId: clientId,
-        createdAt: new Date(),
-      });
-
-      await this.roomRepository.createRoom(roomId, room);
-      await this.roomRepository.joinRoom(clientId, roomId);
-      await client.join(roomId);
-
-      client.emit('roomCreated', {
-        roomId: room.id,
-        hostId: room.hostId,
-      });
-
-      const currentUserCount =
-        await this.roomRepository.getCurrentUsers(roomId);
-
-      this.server.to(roomId).emit('roomUsersUpdated', {
-        roomId: roomId,
-        userCount: currentUserCount,
-      });
-
-      return {
-        success: true,
-        room,
-      };
-    } catch (error) {
-      console.error('Error in createRoom:', error);
-      return {
-        success: false,
-        error: error.message,
-      };
-    }
-  }
-
   @SubscribeMessage('message')
   async handleMessage(
     @ConnectedSocket() client: Socket,

--- a/server/src/room/room.module.ts
+++ b/server/src/room/room.module.ts
@@ -7,6 +7,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AlbumModule } from '@/album/album.module';
 import { SongModule } from '@/song/song.module';
 import { MusicModule } from '@/music/music.module';
+import { RoomService } from '@/room/room.service';
 
 @Module({
   imports: [
@@ -16,7 +17,7 @@ import { MusicModule } from '@/music/music.module';
     MusicModule,
   ],
   controllers: [RoomController],
-  providers: [RoomRepository, RoomGateway],
-  exports: [TypeOrmModule, RoomRepository],
+  providers: [RoomRepository, RoomGateway, RoomService],
+  exports: [TypeOrmModule, RoomService],
 })
 export class RoomModule {}

--- a/server/src/room/room.module.ts
+++ b/server/src/room/room.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { RoomRepository } from '@/room/room.repository';
+import { RoomGateway } from '@/room/room.gateway';
+import { RoomController } from '@/room/room.controller';
+import { Room } from '@/room/room.entity';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Room])],
+  controllers: [RoomController],
+  providers: [RoomRepository, RoomGateway],
+  exports: [TypeOrmModule, RoomRepository],
+})
+export class RoomModule {}

--- a/server/src/room/room.module.ts
+++ b/server/src/room/room.module.ts
@@ -4,9 +4,17 @@ import { RoomGateway } from '@/room/room.gateway';
 import { RoomController } from '@/room/room.controller';
 import { Room } from '@/room/room.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { AlbumModule } from '@/album/album.module';
+import { SongModule } from '@/song/song.module';
+import { MusicModule } from '@/music/music.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Room])],
+  imports: [
+    TypeOrmModule.forFeature([Room]),
+    AlbumModule,
+    SongModule,
+    MusicModule,
+  ],
   controllers: [RoomController],
   providers: [RoomRepository, RoomGateway],
   exports: [TypeOrmModule, RoomRepository],

--- a/server/src/room/room.repository.ts
+++ b/server/src/room/room.repository.ts
@@ -38,7 +38,7 @@ export class RoomRepository {
       .hSet(roomKey, 'createdAt', room.createdAt.toISOString())
       .hSet(roomKey, 'isActive', 'true')
       .hSet(roomKey, 'currentUsers', '0')
-      .hSet(roomKey, 'maxCapacity', '10')
+      .hSet(roomKey, 'maxCapacity', process.env.MAX_CAPACITY || '100')
       .exec();
     return;
   }

--- a/server/src/room/room.repository.ts
+++ b/server/src/room/room.repository.ts
@@ -29,13 +29,12 @@ export class RoomRepository {
     return `rooms:${roomId}:queue`;
   }
 
-  async createRoom(roomId: string, room: Room): Promise<void> {
-    const roomKey = this.roomKey(roomId);
+  async createRoom(room: Room): Promise<void> {
+    const roomKey = this.roomKey(room.id);
 
     await this.redisClient
       .multi()
       .hSet(roomKey, 'id', room.id)
-      .hSet(roomKey, 'hostId', room.hostId)
       .hSet(roomKey, 'createdAt', room.createdAt.toISOString())
       .hSet(roomKey, 'isActive', 'true')
       .hSet(roomKey, 'currentUsers', '0')
@@ -78,16 +77,14 @@ export class RoomRepository {
       return null;
     }
 
-    const [id, name, hostId, createdAt] = await Promise.all([
+    const [id, name, createdAt] = await Promise.all([
       this.redisClient.hGet(roomKey, 'id'),
       this.redisClient.hGet(roomKey, 'name'),
-      this.redisClient.hGet(roomKey, 'hostId'),
       this.redisClient.hGet(roomKey, 'createdAt'),
     ]);
 
     return new Room({
       id,
-      hostId,
       createdAt: new Date(createdAt),
     });
   }

--- a/server/src/room/room.repository.ts
+++ b/server/src/room/room.repository.ts
@@ -43,11 +43,6 @@ export class RoomRepository {
     return;
   }
 
-  async generateRoomId(): Promise<string> {
-    const roomCount = await this.redisClient.incr('room_counter');
-    return `room_${roomCount}`;
-  }
-
   async leaveRoom(userId: string, roomId: string): Promise<void> {
     const roomKey = this.roomKey(roomId);
     const roomUsersKey = this.roomUsersKey(roomId);

--- a/server/src/room/room.service.ts
+++ b/server/src/room/room.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { MusicRepository } from '@/music/music.repository';
+import { Room } from '@/room/room.entity';
+import { RoomRepository } from '@/room/room.repository';
+
+@Injectable()
+export class RoomService {
+  constructor(
+    private readonly roomRepository: RoomRepository,
+    private readonly musicRepository: MusicRepository,
+  ) {}
+
+  async getTrackOrder(roomId: string): Promise<object> {
+    return this.musicRepository.findSongByJoinTimestamp(roomId, Date.now());
+  }
+
+  async initializeRoom(albumId: string) {
+    await this.roomRepository.createRoom(
+      new Room({ id: albumId, createdAt: new Date() }),
+    );
+  }
+}

--- a/server/src/song/song.module.ts
+++ b/server/src/song/song.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Song } from '@/song/song.entity';
+import { SongRepository } from '@/song/song.repository';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Song])],
   controllers: [],
-  providers: [],
-  exports: [],
+  providers: [SongRepository],
+  exports: [SongRepository],
 })
 export class SongModule {}

--- a/server/src/song/song.repository.ts
+++ b/server/src/song/song.repository.ts
@@ -18,4 +18,8 @@ export class SongRepository {
       order: { trackNumber: ORDER[orderBy] },
     });
   }
+
+  async save(song: Song) {
+    return this.repository.save(song);
+  }
 }

--- a/server/src/song/song.repository.ts
+++ b/server/src/song/song.repository.ts
@@ -1,0 +1,21 @@
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Song } from '@/song/song.entity';
+import { ORDER } from '@/common/constants/repository.constant';
+
+export class SongRepository {
+  constructor(
+    @InjectRepository(Song)
+    private readonly repository: Repository<Song>,
+  ) {}
+
+  async findByIdWithOrderByTrackNumber(
+    albumId: string,
+    orderBy: keyof typeof ORDER,
+  ) {
+    return this.repository.find({
+      where: { albumId },
+      order: { trackNumber: ORDER[orderBy] },
+    });
+  }
+}

--- a/server/src/song/song.repository.ts
+++ b/server/src/song/song.repository.ts
@@ -2,7 +2,9 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Song } from '@/song/song.entity';
 import { ORDER } from '@/common/constants/repository.constant';
+import { Injectable } from '@nestjs/common';
 
+@Injectable()
 export class SongRepository {
   constructor(
     @InjectRepository(Song)

--- a/server/src/song/song.repository.ts
+++ b/server/src/song/song.repository.ts
@@ -11,10 +11,7 @@ export class SongRepository {
     private readonly repository: Repository<Song>,
   ) {}
 
-  async findByIdWithOrderByTrackNumber(
-    albumId: string,
-    orderBy: keyof typeof ORDER,
-  ) {
+  async getAlbumTracksSorted(albumId: string, orderBy: keyof typeof ORDER) {
     return this.repository.find({
       where: { albumId },
       order: { trackNumber: ORDER[orderBy] },


### PR DESCRIPTION
close #51 

## 📋개요

- 방 생성 시 불필요한 socket 이벤트 처리를 제거하고, 기존 api/admin/album에 redis 방 생성 로직을 추가하였습니다.
- 방 생성 시 한 명의 사용자를 포함한다는 가정이 제거됨에 따라, 호스트 id에 대한 개념을 삭제했습니다.
- 부가적으로 방 생성 로직이 복잡하여 어드민 서비스 레이어에 역할을 분리하였습니다.
- Song 및 Album에 대해 repository가 없이 InjectRepository를 사용해서 호출했는데,  
query builder 사용에 따라 복잡도가 증가하여 이 부분을 repository 레이어로 분리하였습니다.

## 🕰️예상 리뷰시간

30분

## 📢상세내용

- 방 생성 시 .env에 `MAX_CAPACITY`옵션을 주어야 합니다. 이 옵션은 방 참여 가능 인원수를 의미합니다.
- 방 생성 시 isActive에 대한 타입을 boolean에서 object 타입인 `ROOM_STATUS`로 변경하였습니다.
- SongRepository, AlbumRepository가 추가되었습니다.
- Admin Controller의 방 생성 로직에 RoomRepository를 이용한 redis 정보가 저장되도록 수정했습니다.
- repository 레이어에서 재사용할 수 있도록 `repository.constant.ts`를 만들었고, ORDER entity에 ASC와 DESC로 관리하도록 작성했습니다.
```js
export const ORDER = {
  ASC: 'ASC',
  DESC: 'DESC',
} as const;
```

- 방 생성 메소드에서 일부 로직이 분리되었습니다.
  - 앨범 이미지(커버, 배너)를 S3에 저장하고 반환된 url을 db에 저장하는 로직을 하나의 메소드로 묶었습니다.
  - 음악 재생시간과 releaseTimestamp를 생성하고, 스트리밍 세션 redis에 저장하는 로직을 하나의 메소드로 묶었습니다.
  - 처리된 음악에 대해 db에 정보를 저장하는 로직을 서비스 레이어에 분리하였습니다.


### 리팩토링 후 정상 동작 테스트

redis room 정보

![image](https://github.com/user-attachments/assets/30cf0a52-2918-483b-9e48-d6501b457229)

MySQL 앨범 정보

![image](https://github.com/user-attachments/assets/d37506ab-e72d-4f4a-8748-272f8da70dd4)

MySQL 음악 정보

![image](https://github.com/user-attachments/assets/db87b5bd-8cc0-4f95-b6c5-773dd3aad952)

Object Storage 음악 파일

![image](https://github.com/user-attachments/assets/55476ca1-3b9b-4026-8a2a-739354427587)

![image](https://github.com/user-attachments/assets/5e3cd098-79e8-458c-990d-5c91034f07b6)

![image](https://github.com/user-attachments/assets/a7dc3a39-30c8-4174-8447-14b33072bebf)


## 💥특이사항

- 현재 트랜잭션 처리가 되어있지 않습니다. 음악 데이터를 요청에 추가하지 않은 경우 앨범에 대한 정보만 DB에 저장됩니다.