### PR TITLE
음악 release date 타입 수정

### DIFF
--- a/server/src/admin/admin.controller.ts
+++ b/server/src/admin/admin.controller.ts
@@ -14,6 +14,7 @@ import { AdminService } from './admin.service';
 import { Album } from '@/album/album.entity';
 import { AlbumRepository } from '@/album/album.repository';
 import { RoomService } from '@/room/room.service';
+import { plainToInstance } from 'class-transformer';
 
 export interface UploadedFiles {
   albumCover?: Express.Multer.File;
@@ -42,7 +43,7 @@ export class AdminController {
     @UploadedFiles() files: UploadedFiles,
     @Body('albumData') albumDataString: string,
   ): Promise<any> {
-    const albumData = JSON.parse(albumDataString) as AlbumDto;
+    const albumData = plainToInstance(AlbumDto, JSON.parse(albumDataString));
     const album = await this.albumRepository.save(new Album(albumData));
 
     // 앨범 이미지 업로드 및 DB 저장

--- a/server/src/admin/admin.service.ts
+++ b/server/src/admin/admin.service.ts
@@ -108,7 +108,7 @@ export class AdminService {
 
   async initializeStreamingSession(processedSongs: Song[], album: Album) {
     const songDurations = processedSongs.map((song) => song.duration);
-    const releaseTimestamp = new Date(album.releaseDate).getTime();
+    const releaseTimestamp = album.releaseDate.getTime();
 
     await this.adminRedisRepository.createStreamingSession(
       album.id,

--- a/server/src/admin/dto/AlbumDto.ts
+++ b/server/src/admin/dto/AlbumDto.ts
@@ -1,12 +1,15 @@
 import {
   IsArray,
-  IsISO8601,
+  IsDate,
   IsNotEmpty,
   IsNumber,
+  IsOptional,
   IsString,
   Min,
+  ValidateNested,
 } from 'class-validator';
 import { SongDto } from './SongDto';
+import { Type } from 'class-transformer';
 
 export class AlbumDto {
   @IsNotEmpty()
@@ -18,15 +21,19 @@ export class AlbumDto {
   artist: string;
 
   @IsNotEmpty()
-  @IsISO8601()
-  releaseDate: string;
+  @IsDate()
+  @Type(() => Date)
+  releaseDate: Date;
 
   @IsNotEmpty()
   @IsNumber()
   @Min(0)
+  @IsOptional()
   totalTracks?: number;
 
   @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => SongDto)
   songs: SongDto[];
 
   @IsString()

--- a/server/src/album/album.entity.ts
+++ b/server/src/album/album.entity.ts
@@ -17,11 +17,10 @@ export class Album {
 
   @Column({
     name: 'release_date',
-    type: 'char',
-    length: 19,
+    type: 'timestamp',
     nullable: false,
   })
-  releaseDate: string;
+  releaseDate: Date;
 
   @Column({ name: 'banner_url', type: 'varchar', length: 500 })
   bannerUrl: string;

--- a/server/src/album/albumResponse.dto.ts
+++ b/server/src/album/albumResponse.dto.ts
@@ -14,7 +14,7 @@ export class AlbumResponseDto {
   tags: string;
 
   @Expose()
-  releaseDate: string;
+  releaseDate: Date;
 
   @Expose()
   bannerUrl: string;


### PR DESCRIPTION
## 📋개요

MySQL에 저장된 release_date에 대한 타입이 string 타입이었기 때문에 현재 날짜와 비교할 때 문제가 있었습니다.  
이 문제를 해결하기 위해 타입을 timestamp로 수정해주었습니다.

## 🕰️예상 리뷰시간

## 📢상세내용

- MySQL release_date 타입을 timestamp로 수정
- Album entity의 releaseDate 타입을 Date로 수정
- AlbumDto의 releaseDate 타입을 Date로 수정
- 클라이언트로부터 albumDto를 받아올 때 타입 변환 방식수정

![image](https://github.com/user-attachments/assets/72df6cdc-db93-4bcf-994e-d5ec7b495c74)


## 💥특이사항

- 로컬 환경에서 로컬 MySQL을 연결했는데 서버 MySQL을 수정하여 많은 시간을 지체했습니다.................