### PR TITLE
사용자 투표 이벤트에 따른 업데이트 처리

### DIFF
--- a/server/src/common/exceptions/domain/room/user-room-info-not-found.exception.ts
+++ b/server/src/common/exceptions/domain/room/user-room-info-not-found.exception.ts
@@ -1,0 +1,10 @@
+import { BaseException } from '@/common/exceptions/base.exception';
+import { HttpStatus } from '@nestjs/common';
+
+export class UserRoomInfoNotFoundException extends BaseException {
+  constructor(socketId: string) {
+    super('사용자의 방 정보가 존재하지 않습니다.', HttpStatus.BAD_REQUEST, {
+      socketId,
+    });
+  }
+}

--- a/server/src/common/exceptions/domain/vote/already-vote-this-room.exception.ts
+++ b/server/src/common/exceptions/domain/vote/already-vote-this-room.exception.ts
@@ -1,0 +1,8 @@
+import { BaseException } from '@/common/exceptions/base.exception';
+import { HttpStatus } from '@nestjs/common';
+
+export class AlreadyVoteThisRoomException extends BaseException {
+  constructor(roomId: string) {
+    super('이미 투표한 방입니다.', HttpStatus.BAD_REQUEST, { roomId });
+  }
+}

--- a/server/src/room/room.gateway.ts
+++ b/server/src/room/room.gateway.ts
@@ -160,7 +160,22 @@ export class RoomGateway
   }
 
   async emitVoteUpdateToRoom(roomId: string) {
-    const voteResult = await this.roomService.getVoteResult(roomId);
+    const voteResult: { [key: string]: string } =
+      await this.roomService.getVoteResult(roomId);
+
+    const totalVote = this.getTotalVote(voteResult);
+
+    Object.entries(voteResult).map(([key, value]) => {
+      voteResult[key] = `${((Number(value) / totalVote) * 100).toFixed(2)}%`;
+    });
+
     this.server.to(roomId).emit('voteUpdated', voteResult);
+  }
+
+  private getTotalVote(voteResult: { [key: string]: string }): number {
+    return Object.values(voteResult).reduce(
+      (acc, value) => acc + Number(value),
+      0,
+    );
   }
 }

--- a/server/src/room/room.gateway.ts
+++ b/server/src/room/room.gateway.ts
@@ -14,6 +14,7 @@ import { RandomNameUtil } from '@/common/randomname/random-name.util';
 import { RoomNotFoundException } from '@/common/exceptions/domain/room/room-not-found.exception';
 import { UserRoomInfoNotFoundException } from '@/common/exceptions/domain/room/user-room-info-not-found.exception';
 import { RoomService } from '@/room/room.service';
+import * as crypto from 'crypto';
 
 @WebSocketGateway({
   namespace: 'rooms',
@@ -132,7 +133,11 @@ export class RoomGateway
       }
 
       const roomId = client.handshake.query.roomId as string;
-      await this.roomService.updateVote(roomId, data.trackNumber);
+      const identifier = crypto
+        .createHash('sha256')
+        .update(client.handshake.address)
+        .digest('hex');
+      await this.roomService.updateVote(roomId, data.trackNumber, identifier);
       await this.emitVoteUpdateToRoom(roomId);
 
       return {

--- a/server/src/room/room.service.ts
+++ b/server/src/room/room.service.ts
@@ -1,13 +1,16 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { MusicRepository } from '@/music/music.repository';
 import { Room } from '@/room/room.entity';
 import { RoomRepository } from '@/room/room.repository';
+import { REDIS_CLIENT } from '@/common/redis/redis.module';
+import { RedisClientType } from 'redis';
 
 @Injectable()
 export class RoomService {
   constructor(
     private readonly roomRepository: RoomRepository,
     private readonly musicRepository: MusicRepository,
+    @Inject(REDIS_CLIENT) private readonly redisClient: RedisClientType,
   ) {}
 
   async getTrackOrder(roomId: string): Promise<string> {
@@ -24,5 +27,25 @@ export class RoomService {
       // new Room({ id: albumId, createdAt: new Date() }),
       new Room({ id: albumId, createdAt: new Date(1700000000000) }),
     );
+  }
+
+  async updateVote(roomId: string, trackNumber: string) {
+    await this.redisClient.hIncrBy(`room:${roomId}:votes`, trackNumber, 1);
+  }
+
+  async getVoteResult(roomId: string) {
+    const voteResult = await this.redisClient.hGetAll(`room:${roomId}:votes`);
+    const songDurations = await this.redisClient.hGet(
+      `rooms:${roomId}:session`,
+      'songs',
+    );
+    const songCount = JSON.parse(songDurations).length;
+    for (let songIndex = 1; songIndex <= songCount; songIndex++) {
+      if (!voteResult[songIndex]) {
+        voteResult[songIndex] = '0';
+      }
+    }
+
+    return voteResult;
   }
 }

--- a/server/src/room/room.service.ts
+++ b/server/src/room/room.service.ts
@@ -44,9 +44,7 @@ export class RoomService {
     const songDurations = await this.roomRepository.findSongDuration(roomId);
     const songCount = JSON.parse(songDurations).length;
     for (let songIndex = 1; songIndex <= songCount; songIndex++) {
-      if (!voteResult[songIndex]) {
-        voteResult[songIndex] = '0';
-      }
+      voteResult[songIndex] = voteResult[songIndex] || '0';
     }
 
     return voteResult;

--- a/server/src/room/room.service.ts
+++ b/server/src/room/room.service.ts
@@ -31,13 +31,23 @@ export class RoomService {
   }
 
   async updateVote(roomId: string, trackNumber: string, identifier: string) {
-    if (await this.redisClient.hExists(`room:${roomId}`, identifier)) {
+    if (
+      await this.redisClient.hExists(`room:${roomId}:votes:users`, identifier)
+    ) {
       throw new AlreadyVoteThisRoomException(roomId);
     }
 
     await this.redisClient.hIncrBy(`room:${roomId}:votes`, trackNumber, 1);
-    await this.redisClient.hSet(`room:${roomId}`, identifier, 'true');
-    await this.redisClient.hExpire(`room:${roomId}`, identifier, 60 * 60 * 24);
+    await this.redisClient.hSet(
+      `room:${roomId}:votes:users`,
+      identifier,
+      'true',
+    );
+    await this.redisClient.hExpire(
+      `room:${roomId}:votes:users`,
+      identifier,
+      60 * 60 * 24,
+    );
   }
 
   async getVoteResult(roomId: string) {


### PR DESCRIPTION
close #118 

## 📋개요

최애 곡을 실시간으로 투표하고 업데이트 된 정보를 실시간으로 반환하여 사용자들에게 노출합니다.

## 🕰️예상 리뷰시간

## 📢상세내용

- redis의 vote 정보 업데이트
  - vote 이벤트 발생 시 voteCount가 증가합니다.
  - trackNumber는 해당 방에 존재하는 음악 트랙 번호를 의미합니다.
  - 현재 vote 정보는 expired 되지 않습니다.
  ```
  key: rooms:{id}:votes
  field: {trackNumber}
  value: {voteCount}
  ```

- redis의 사용자 vote 정보 업데이트
  - vote 이벤트 발생 시 사용자 identifier를 저장하여 중복 투표를 방지합니다.
  - 설정된 expired 시간은 1일입니다.

  ```
  key: rooms:{id}:votes:users
  field: {user identifier}
  values: true
  ```

- socket을 통해 실시간 vote 정보 업데이트
  - vote 이벤트가 성공적으로 실행된 후 voteUpdated 이벤트를 같은 방 클라이언트에 전송합니다.
  - 1번부터 마지막 트랙 번호까지 object 형식으로 전달합니다.

![image](https://github.com/user-attachments/assets/b1e2f693-379d-418a-b002-3c53dce1281c)

## 💥특이사항

- vote 정보에 대해 expired를 할 지에 대해 고민했습니다만 조언을 받고싶습니다.
- vote 취소에 대한 기능이 구현되어있지 않습니다.
  - +1에 대한 redis 명령어만 구현되어 있습니다.
  - 이미 투표한 사용자의 identifier를 제거하는 로직은 구현되어있지 않았습니다.
  - 반대로 위 두 기능을 구현할 경우 투표 취소가 가능합니다.