### PR TITLE
최근 등록 앨범 가져오는 API 추가

### DIFF
--- a/server/src/album/album.controller.ts
+++ b/server/src/album/album.controller.ts
@@ -13,7 +13,7 @@ export class AlbumController {
   }
 
   @Get('sidebar')
-  async getSideBarInfos() {
+  async getSideBarInfos(): Promise<SideBarResponseDto> {
     return await this.albumService.getSideBarInfos();
   }
 }

--- a/server/src/album/album.controller.ts
+++ b/server/src/album/album.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get } from '@nestjs/common';
 import { AlbumService } from './album.service';
 import { MainBannerResponseDto } from './dto/main-banner-response.dto';
 import { SideBarResponseDto } from './dto/side-bar-response.dto';
+import { EndedAlbumResponseDto } from './dto/ended-album-response.dto';
 
 @Controller('album')
 export class AlbumController {
@@ -15,5 +16,10 @@ export class AlbumController {
   @Get('sidebar')
   async getSideBarInfos(): Promise<SideBarResponseDto> {
     return await this.albumService.getSideBarInfos();
+  }
+
+  @Get('ended')
+  async getEndedAlbums(): Promise<EndedAlbumResponseDto> {
+    return await this.albumService.getEndedAlbums();
   }
 }

--- a/server/src/album/album.service.ts
+++ b/server/src/album/album.service.ts
@@ -6,6 +6,7 @@ import {
   MainBannerResponseDto,
 } from './dto/main-banner-response.dto';
 import { SideBarResponseDto } from './dto/side-bar-response.dto';
+import { EndedAlbumResponseDto } from './dto/ended-album-response.dto';
 
 @Injectable()
 export class AlbumService {
@@ -36,5 +37,12 @@ export class AlbumService {
     const upComingAlbums =
       await this.albumRepository.getUpComingSideBarInfos(date);
     return new SideBarResponseDto(recentSideBarAlbums, upComingAlbums);
+  }
+
+  async getEndedAlbums() {
+    const date = new Date();
+    const recentAlbums = await this.albumRepository.getEndedAlbumsInfos(date);
+
+    return new EndedAlbumResponseDto(recentAlbums);
   }
 }

--- a/server/src/album/dto/ended-album-response.dto.ts
+++ b/server/src/album/dto/ended-album-response.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class EndedAlbumResponseDto {
+  @ApiProperty({ type: () => EndedAlbumResponse, isArray: true })
+  result: {
+    endedAlbums: EndedAlbumResponse[];
+  };
+
+  constructor(endedAlbums: EndedAlbumResponse[]) {
+    this.result = {
+      endedAlbums,
+    };
+  }
+}
+
+export class EndedAlbumResponse {
+  @ApiProperty()
+  albumId: string;
+  @ApiProperty()
+  albumName: string;
+  @ApiProperty()
+  artist: string;
+  @ApiProperty()
+  albumTags: string;
+}


### PR DESCRIPTION
close #121 
## 📋개요
메인 페이지의 최근 등록 앨범 가져오는 API를 추가했습니다.
## 🕰️예상 리뷰시간
3분
## 📢상세내용
### 가져오는 기준
스트리밍 종료 시간 < 현재 시간이고, 종료된 지 7일 이내인 앨범을 최근 끝난 것부터 정렬합니다
## 💥특이사항
- 종료된 지 7일정도면 괜찮을까요? 한 달 정도로 늘려야할까요?