### PR TITLE
gateway에서 발생하는 예외 처리

### DIFF
--- a/server/src/common/exceptions/ws-exception.filter.ts
+++ b/server/src/common/exceptions/ws-exception.filter.ts
@@ -1,7 +1,7 @@
-import { ArgumentsHost, Catch } from '@nestjs/common';
+import { ArgumentsHost, Catch, WsExceptionFilter } from '@nestjs/common';
 
 @Catch()
-export class WsExceptionFilter implements WsExceptionFilter {
+export class CustomWsExceptionFilter implements WsExceptionFilter {
   catch(exception: any, host: ArgumentsHost) {
     const client = host.switchToWs().getClient();
 

--- a/server/src/common/exceptions/ws-exception.filter.ts
+++ b/server/src/common/exceptions/ws-exception.filter.ts
@@ -1,0 +1,14 @@
+import { ArgumentsHost, Catch } from '@nestjs/common';
+
+@Catch()
+export class WsExceptionFilter implements WsExceptionFilter {
+  catch(exception: any, host: ArgumentsHost) {
+    const client = host.switchToWs().getClient();
+
+    client.emit('error', {
+      error: exception.constructor.name,
+      message: exception.message,
+      time: exception.time || new Date().toISOString(),
+    });
+  }
+}

--- a/server/src/room/room.gateway.ts
+++ b/server/src/room/room.gateway.ts
@@ -16,9 +16,9 @@ import { UserRoomInfoNotFoundException } from '@/common/exceptions/domain/room/u
 import { RoomService } from '@/room/room.service';
 import * as crypto from 'crypto';
 import { UseFilters } from '@nestjs/common';
-import { WsExceptionFilter } from '@/common/exceptions/ws-exception.filter';
+import { CustomWsExceptionFilter } from '@/common/exceptions/ws-exception.filter';
 
-@UseFilters(WsExceptionFilter)
+@UseFilters(CustomWsExceptionFilter)
 @WebSocketGateway({
   namespace: 'rooms',
   cors: {

--- a/server/src/room/room.gateway.ts
+++ b/server/src/room/room.gateway.ts
@@ -15,7 +15,10 @@ import { RoomNotFoundException } from '@/common/exceptions/domain/room/room-not-
 import { UserRoomInfoNotFoundException } from '@/common/exceptions/domain/room/user-room-info-not-found.exception';
 import { RoomService } from '@/room/room.service';
 import * as crypto from 'crypto';
+import { UseFilters } from '@nestjs/common';
+import { WsExceptionFilter } from '@/common/exceptions/ws-exception.filter';
 
+@UseFilters(WsExceptionFilter)
 @WebSocketGateway({
   namespace: 'rooms',
   cors: {
@@ -69,33 +72,38 @@ export class RoomGateway
 
   async handleDisconnect(client: Socket) {
     console.log(`Client disconnected: ${client.id}`);
-    const roomId = client.handshake.query.roomId as string;
-    const room = await this.roomRepository.findRoom(roomId);
+    try {
+      const roomId = client.handshake.query.roomId as string;
+      const room = await this.roomRepository.findRoom(roomId);
 
-    if (!room) {
-      throw new RoomNotFoundException();
+      if (!room) {
+        throw new RoomNotFoundException();
+      }
+
+      const clientId = client.id;
+      await this.roomRepository.leaveRoom(client.id, roomId);
+
+      const currentUserCount =
+        await this.roomRepository.getCurrentUsers(roomId);
+      await client.leave(roomId);
+
+      client.emit('leavedRoom', {
+        roomId,
+        userId: clientId,
+        timestamp: new Date(),
+      });
+      this.server.to(roomId).emit('roomUsersUpdated', {
+        roomId,
+        userCount: currentUserCount,
+      });
+
+      return {
+        success: true,
+        message: `Successfully left room ${roomId}`,
+      };
+    } catch (error) {
+      console.error('Error in handleDisconnectConnection:', error);
     }
-
-    const clientId = client.id;
-    await this.roomRepository.leaveRoom(client.id, roomId);
-
-    const currentUserCount = await this.roomRepository.getCurrentUsers(roomId);
-    await client.leave(roomId);
-
-    client.emit('leavedRoom', {
-      roomId,
-      userId: clientId,
-      timestamp: new Date(),
-    });
-    this.server.to(roomId).emit('roomUsersUpdated', {
-      roomId,
-      userCount: currentUserCount,
-    });
-
-    return {
-      success: true,
-      message: `Successfully left room ${roomId}`,
-    };
   }
 
   @SubscribeMessage('message')


### PR DESCRIPTION
close #126 

## 📋개요

기존 global exception이 gateway에서 발생하는 예외를 잡지 못하는 문제를 해결해야 했습니다.

## 🕰️예상 리뷰시간

3분

## 📢상세내용

- WsExceptionFilter를 상속받는 CustomWsExceptionFilter 구현
- room gateway에서 WsExceptionFilter를 사용하도록 작성
- disconnect 메소드 내부에 try-catch를 추가했습니다.

![image](https://github.com/user-attachments/assets/e71d4f86-ba49-4f92-bcc1-625072a01783)


## 💥특이사항

- gateway에서 발생한 오류가 자체적으로 처리되어 로그만 띄우고 서버를 종료하지는 않았습니다.
- 다만, connection 또는 disconnection, afterInit의 경우 인터페이스 메소드이며, 예외가 발생했을 때 filter에 걸리지 않는 문제가 있었습니다.
  - 이 문제를 해결하기 위해 connection, disconnection, afterInit 메소드는 무조건 try-catch로 처리되어야 합니다.
- 위 3개 메소드를 제외하고도 나머지 이벤트 처리 메소드도 try-catch를 사용하기에 큰 에러 상황 없이 처리되지만,  
예외 상황을 위해 filter를 정의하게 되었습니다.