### PR TITLE
최근 등록한 앨범 데이터 연동

### DIFF
--- a/client/src/entities/room/types.ts
+++ b/client/src/entities/room/types.ts
@@ -24,3 +24,19 @@ export interface bannerData {
   currentUserCount: number;
   releaseDate: string;
 }
+
+/**
+ * 메인 페이지 최근 스트리밍 앨범 정보
+ */
+
+export interface EndedAlbumListResponse {
+  endedAlbums: EndedAlbumData[];
+}
+
+export interface EndedAlbumData {
+  albumId: string;
+  albumName: string;
+  artist: string;
+  albumTags?: string;
+  jacketUrl?: string;
+}

--- a/client/src/shared/api/publicAPI.ts
+++ b/client/src/shared/api/publicAPI.ts
@@ -89,4 +89,12 @@ export const publicAPI = {
       throw error;
     }
   },
+  getAlbumEnded: async () => {
+    try {
+      const { data } = await publicInstance.get('/album/ended');
+      return data;
+    } catch (error) {
+      throw error;
+    }
+  },
 };

--- a/client/src/widgets/albums/ui/AlbumCard.tsx
+++ b/client/src/widgets/albums/ui/AlbumCard.tsx
@@ -6,7 +6,7 @@ export function AlbumCard({ album }: { album: Album }) {
       <img
         src={album.coverImage}
         alt={`${album.title} 앨범 커버`}
-        className="mb-3"
+        className="mb-3 w-[200px] h-[200px] object-cover"
       />
       <p className="text-xl font-semibold mb-1">{album.title}</p>
       <p className="mb-2">{album.artist}</p>

--- a/client/src/widgets/albums/ui/AlbumList.tsx
+++ b/client/src/widgets/albums/ui/AlbumList.tsx
@@ -1,22 +1,41 @@
 import LogoAlbum from '@/assets/logo-album-cover.png';
 import { AlbumCard } from './AlbumCard';
-import { Album } from '@/entities/album/types';
-
-const mockAlbums: Album[] = Array.from({ length: 7 }, (_, index) => ({
-  id: index,
-  title: '앨범명명명',
-  artist: '가수명명명',
-  tags: ['태그', '태그', '태그'],
-  coverImage: LogoAlbum,
-}));
+import { useEffect, useState } from 'react';
+import { EndedAlbumListResponse } from '@/entities/room/types';
+import { publicAPI } from '@/shared/api/publicAPI';
 
 export function AlbumList() {
+  const [endedAlbumList, setEndedAlbumList] =
+    useState<EndedAlbumListResponse>();
+
+  useEffect(() => {
+    const getAlbumEnded = async () => {
+      const res = await publicAPI
+        .getAlbumEnded()
+        .then((res) => res)
+        .catch((err) => console.log(err));
+      setEndedAlbumList(res.result);
+    };
+
+    getAlbumEnded();
+  }, []);
+
+  if (!endedAlbumList) return null;
   return (
     <div className="text-grayscale-50">
       <p className="mt-[70px] mb-7 text-3xl font-bold">최근 등록된 앨범</p>
       <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 xl:grid-cols-7 gap-9">
-        {mockAlbums.map((album) => (
-          <AlbumCard key={album.id} album={album} />
+        {endedAlbumList.endedAlbums.map((album) => (
+          <AlbumCard
+            key={album.albumId}
+            album={{
+              id: album.albumId,
+              title: album.albumName,
+              artist: album.artist,
+              tags: album.albumTags ? [album.albumTags] : [],
+              coverImage: album.jacketUrl || LogoAlbum,
+            }}
+          />
         ))}
       </ul>
     </div>

--- a/server/src/album/album.repository.ts
+++ b/server/src/album/album.repository.ts
@@ -68,9 +68,12 @@ export class AlbumRepository {
         'release_date as releaseDate',
         'banner_url as bannerImageUrl',
       ])
-      .where('DATE_ADD(release_date, INTERVAL total_duration SECOND) > :currentTime', {
-        currentTime,
-      })
+      .where(
+        'DATE_ADD(release_date, INTERVAL total_duration SECOND) > :currentTime',
+        {
+          currentTime,
+        },
+      )
       .andWhere('release_date <= DATE_ADD(:currentTime, INTERVAL 3 DAY)', {
         currentTime,
       })
@@ -132,6 +135,7 @@ export class AlbumRepository {
         'title as albumName',
         'artist',
         'tags as albumTags',
+        'jacket_url as jacketUrl',
       ])
       .where(
         'DATE_ADD(release_date, INTERVAL total_duration SECOND) < :currentTime',
@@ -167,4 +171,5 @@ export class GetEndedAlbumInfosTuple {
   albumName: string;
   artist: string;
   albumTags: string;
+  jacketUrl: string;
 }

--- a/server/src/album/dto/ended-album-response.dto.ts
+++ b/server/src/album/dto/ended-album-response.dto.ts
@@ -22,4 +22,6 @@ export class EndedAlbumResponse {
   artist: string;
   @ApiProperty()
   albumTags: string;
+  @ApiProperty()
+  jacketUrl: string;
 }


### PR DESCRIPTION
close #128 
## 📋개요
최근 등록한 앨범 프론트 페이지와 데이터를 연동했습니다
## 🕰️예상 리뷰시간
<5분
## 📢상세내용
- PublicUrl 설정
- type 설정
- 이미지 크기 고정

### 구현 결과
![image](https://github.com/user-attachments/assets/d1019fae-ece9-40d2-9b54-ccf8cc61a7cc)

## 💥특이사항
이미지 크기가 모두 달라서 `AlbumCard`의 img 태그에 고정 값을 줬는데, 이게 맞는 방법인지 모르겠습니다

@chaeryeon823 