### PR TITLE
앨범 상세 API 구현

### DIFF
--- a/server/src/album/album.controller.ts
+++ b/server/src/album/album.controller.ts
@@ -1,8 +1,10 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Param } from '@nestjs/common';
 import { AlbumService } from './album.service';
 import { MainBannerResponseDto } from './dto/main-banner-response.dto';
 import { SideBarResponseDto } from './dto/side-bar-response.dto';
 import { EndedAlbumResponseDto } from './dto/ended-album-response.dto';
+import { AlbumDetailResponseDto } from './dto/album-detail-response.dto';
+import { ApiParam, ApiResponse } from '@nestjs/swagger';
 
 @Controller('album')
 export class AlbumController {
@@ -21,5 +23,14 @@ export class AlbumController {
   @Get('ended')
   async getEndedAlbums(): Promise<EndedAlbumResponseDto> {
     return await this.albumService.getEndedAlbums();
+  }
+
+  @Get(':albumId')
+  @ApiParam({ name: 'albumId', required: true })
+  @ApiResponse({ status: 200, description: `success to get album detail` })
+  async getAlbumDetail(
+    @Param('albumId') albumId: string,
+  ): Promise<AlbumDetailResponseDto> {
+    return await this.albumService.getAlbumDetail(albumId);
   }
 }

--- a/server/src/album/album.repository.ts
+++ b/server/src/album/album.repository.ts
@@ -4,6 +4,12 @@ import { Album } from '@/album/album.entity';
 import { DataSource, Repository } from 'typeorm';
 import { plainToInstance } from 'class-transformer';
 import { Song } from '@/song/song.entity';
+import {
+  AlbumDetailDto,
+  AlbumDetailSongDto,
+} from './dto/album-detail-response.dto';
+import { EndedAlbumDto } from './dto/ended-album-response.dto';
+import { SideBarDto } from './dto/side-bar-response.dto';
 
 @Injectable()
 export class AlbumRepository {
@@ -100,9 +106,7 @@ export class AlbumRepository {
   }
 
   // 스트리밍 시작 시간 <= currentTIme < 스트리밍 끝나는 시간
-  async getRecentSideBarInfos(
-    currentTime: Date,
-  ): Promise<GetSideBarInfosTuple[]> {
+  async getRecentSideBarInfos(currentTime: Date): Promise<SideBarDto[]> {
     const recentSideBarInfos = await this.dataSource
       .createQueryBuilder()
       .from(Album, 'album')
@@ -118,13 +122,11 @@ export class AlbumRepository {
       )
       .getRawMany();
 
-    return plainToInstance(GetSideBarInfosTuple, recentSideBarInfos);
+    return plainToInstance(SideBarDto, recentSideBarInfos);
   }
 
   // 스트리밍 끝나는 시간 < currentTime <= 현재시간으로 부터 6시간 뒤
-  async getUpComingSideBarInfos(
-    currentTime: Date,
-  ): Promise<GetSideBarInfosTuple[]> {
+  async getUpComingSideBarInfos(currentTime: Date): Promise<SideBarDto[]> {
     const upComingAlbumInfos = await this.dataSource
       .createQueryBuilder()
       .from(Album, 'album')
@@ -137,13 +139,11 @@ export class AlbumRepository {
       })
       .getRawMany();
 
-    return plainToInstance(GetSideBarInfosTuple, upComingAlbumInfos);
+    return plainToInstance(SideBarDto, upComingAlbumInfos);
   }
 
   // 스트리밍 종료 시간 < 현재 시간, 종료된지 7일 이내인 앨범 최근 끝난 것부터 정렬
-  async getEndedAlbumsInfos(
-    currentTime: Date,
-  ): Promise<GetEndedAlbumInfosTuple[]> {
+  async getEndedAlbumsInfos(currentTime: Date): Promise<EndedAlbumDto[]> {
     const endedAlbumInfos = await this.dataSource
       .createQueryBuilder()
       .from(Album, 'album')
@@ -164,12 +164,10 @@ export class AlbumRepository {
       .orderBy('DATE_ADD(release_date, INTERVAL total_duration SECOND)', 'DESC')
       .getRawMany();
 
-    return plainToInstance(GetEndedAlbumInfosTuple, endedAlbumInfos);
+    return plainToInstance(EndedAlbumDto, endedAlbumInfos);
   }
 
-  async getAlbumDetailInfos(
-    albumId: string,
-  ): Promise<GetAlbumDetailInfosTuple> {
+  async getAlbumDetailInfos(albumId: string): Promise<AlbumDetailDto> {
     const albumDetailInfos = await this.dataSource
       .createQueryBuilder()
       .from(Album, 'album')
@@ -182,12 +180,12 @@ export class AlbumRepository {
       .where('id = :albumId', { albumId })
       .getRawOne();
 
-    return plainToInstance(GetAlbumDetailInfosTuple, albumDetailInfos);
+    return plainToInstance(AlbumDetailDto, albumDetailInfos);
   }
 
   async getAlbumDetailSongInfos(
     albumId: string,
-  ): Promise<GetAlbumDetailSongInfosTuple[]> {
+  ): Promise<AlbumDetailSongDto[]> {
     const albumDetailSongInfos = await this.dataSource
       .createQueryBuilder()
       .from(Song, 'song')
@@ -195,7 +193,7 @@ export class AlbumRepository {
       .where('album_id = :albumId', { albumId })
       .getRawMany();
 
-    return plainToInstance(GetAlbumDetailSongInfosTuple, albumDetailSongInfos);
+    return plainToInstance(AlbumDetailSongDto, albumDetailSongInfos);
   }
 }
 
@@ -206,30 +204,4 @@ export class GetAlbumBannerInfosTuple {
   artist: string;
   releaseDate: Date;
   bannerImageUrl: string;
-}
-
-export class GetSideBarInfosTuple {
-  albumId: string;
-  albumName: string;
-  albumTags: string;
-}
-
-export class GetEndedAlbumInfosTuple {
-  albumId: string;
-  albumName: string;
-  artist: string;
-  albumTags: string;
-  jacketUrl: string;
-}
-
-export class GetAlbumDetailInfosTuple {
-  albumId: string;
-  albumName: string;
-  artist: string;
-  jacketUrl: string;
-}
-
-export class GetAlbumDetailSongInfosTuple {
-  songName: string;
-  songDuration: number;
 }

--- a/server/src/album/album.repository.ts
+++ b/server/src/album/album.repository.ts
@@ -3,6 +3,7 @@ import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 import { Album } from '@/album/album.entity';
 import { DataSource, Repository } from 'typeorm';
 import { plainToInstance } from 'class-transformer';
+import { Song } from '@/song/song.entity';
 
 @Injectable()
 export class AlbumRepository {
@@ -165,6 +166,37 @@ export class AlbumRepository {
 
     return plainToInstance(GetEndedAlbumInfosTuple, endedAlbumInfos);
   }
+
+  async getAlbumDetailInfos(
+    albumId: string,
+  ): Promise<GetAlbumDetailInfosTuple> {
+    const albumDetailInfos = await this.dataSource
+      .createQueryBuilder()
+      .from(Album, 'album')
+      .select([
+        'album.id as albumId',
+        'album.title as albumName',
+        'artist',
+        'jacket_url as jacketUrl',
+      ])
+      .where('id = :albumId', { albumId })
+      .getRawOne();
+
+    return plainToInstance(GetAlbumDetailInfosTuple, albumDetailInfos);
+  }
+
+  async getAlbumDetailSongInfos(
+    albumId: string,
+  ): Promise<GetAlbumDetailSongInfosTuple[]> {
+    const albumDetailSongInfos = await this.dataSource
+      .createQueryBuilder()
+      .from(Song, 'song')
+      .select(['song.title as songName', 'song.duration as songDuration'])
+      .where('album_id = :albumId', { albumId })
+      .getRawMany();
+
+    return plainToInstance(GetAlbumDetailSongInfosTuple, albumDetailSongInfos);
+  }
 }
 
 export class GetAlbumBannerInfosTuple {
@@ -188,4 +220,16 @@ export class GetEndedAlbumInfosTuple {
   artist: string;
   albumTags: string;
   jacketUrl: string;
+}
+
+export class GetAlbumDetailInfosTuple {
+  albumId: string;
+  albumName: string;
+  artist: string;
+  jacketUrl: string;
+}
+
+export class GetAlbumDetailSongInfosTuple {
+  songName: string;
+  songDuration: number;
 }

--- a/server/src/album/album.service.ts
+++ b/server/src/album/album.service.ts
@@ -30,7 +30,7 @@ export class AlbumService {
     return new MainBannerResponseDto(banners);
   }
 
-  async getSideBarInfos() {
+  async getSideBarInfos(): Promise<SideBarResponseDto> {
     const date = new Date();
     const recentSideBarAlbums =
       await this.albumRepository.getRecentSideBarInfos(date);
@@ -40,7 +40,7 @@ export class AlbumService {
     return new SideBarResponseDto(recentSideBarAlbums, upComingAlbums);
   }
 
-  async getEndedAlbums() {
+  async getEndedAlbums(): Promise<EndedAlbumResponseDto> {
     const date = new Date();
     const recentAlbums = await this.albumRepository.getEndedAlbumsInfos(date);
 

--- a/server/src/album/album.service.ts
+++ b/server/src/album/album.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { AlbumRepository } from './album.repository';
 import { AlbumRedisRepository } from './album.redis.repository';
 import {
-  MainBannerResponse,
+  MainBannerDto,
   MainBannerResponseDto,
 } from './dto/main-banner-response.dto';
 import { SideBarResponseDto } from './dto/side-bar-response.dto';
@@ -24,7 +24,7 @@ export class AlbumService {
       albumBannerInfos.map(async (album) => {
         const currentUserCount =
           await this.albumRedisRepository.getCurrentUsers(album.albumId);
-        return MainBannerResponse.from(album, currentUserCount);
+        return MainBannerDto.from(album, currentUserCount);
       }),
     );
     return new MainBannerResponseDto(banners);

--- a/server/src/album/album.service.ts
+++ b/server/src/album/album.service.ts
@@ -7,6 +7,7 @@ import {
 } from './dto/main-banner-response.dto';
 import { SideBarResponseDto } from './dto/side-bar-response.dto';
 import { EndedAlbumResponseDto } from './dto/ended-album-response.dto';
+import { AlbumDetailResponseDto } from './dto/album-detail-response.dto';
 
 @Injectable()
 export class AlbumService {
@@ -44,5 +45,12 @@ export class AlbumService {
     const recentAlbums = await this.albumRepository.getEndedAlbumsInfos(date);
 
     return new EndedAlbumResponseDto(recentAlbums);
+  }
+
+  async getAlbumDetail(albumId: string): Promise<AlbumDetailResponseDto> {
+    const albumDetail = await this.albumRepository.getAlbumDetailInfos(albumId);
+    const albumSongDetail =
+      await this.albumRepository.getAlbumDetailSongInfos(albumId);
+    return new AlbumDetailResponseDto(albumDetail, albumSongDetail);
   }
 }

--- a/server/src/album/dto/album-detail-response.dto.ts
+++ b/server/src/album/dto/album-detail-response.dto.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AlbumDetailResponseDto {
+  result: {
+    albumDetails: AlbumDetailResponse;
+    songDetails: AlbumDetailSongResponse[];
+  };
+  constructor(
+    albumDetails: AlbumDetailResponse,
+    songDetails: AlbumDetailSongResponse[],
+  ) {
+    this.result = {
+      albumDetails,
+      songDetails,
+    };
+  }
+}
+
+export class AlbumDetailResponse {
+  @ApiProperty()
+  albumId: string;
+  @ApiProperty()
+  albumName: string;
+  @ApiProperty()
+  artist: string;
+  @ApiProperty()
+  jacketUrl: string;
+}
+
+export class AlbumDetailSongResponse {
+  @ApiProperty()
+  songName: string;
+  @ApiProperty()
+  songDuration: number;
+}

--- a/server/src/album/dto/album-detail-response.dto.ts
+++ b/server/src/album/dto/album-detail-response.dto.ts
@@ -2,12 +2,12 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class AlbumDetailResponseDto {
   result: {
-    albumDetails: AlbumDetailResponse;
-    songDetails: AlbumDetailSongResponse[];
+    albumDetails: AlbumDetailDto;
+    songDetails: AlbumDetailSongDto[];
   };
   constructor(
-    albumDetails: AlbumDetailResponse,
-    songDetails: AlbumDetailSongResponse[],
+    albumDetails: AlbumDetailDto,
+    songDetails: AlbumDetailSongDto[],
   ) {
     this.result = {
       albumDetails,
@@ -16,7 +16,7 @@ export class AlbumDetailResponseDto {
   }
 }
 
-export class AlbumDetailResponse {
+export class AlbumDetailDto {
   @ApiProperty()
   albumId: string;
   @ApiProperty()
@@ -27,7 +27,7 @@ export class AlbumDetailResponse {
   jacketUrl: string;
 }
 
-export class AlbumDetailSongResponse {
+export class AlbumDetailSongDto {
   @ApiProperty()
   songName: string;
   @ApiProperty()

--- a/server/src/album/dto/ended-album-response.dto.ts
+++ b/server/src/album/dto/ended-album-response.dto.ts
@@ -1,19 +1,19 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class EndedAlbumResponseDto {
-  @ApiProperty({ type: () => EndedAlbumResponse, isArray: true })
+  @ApiProperty({ type: () => EndedAlbumDto, isArray: true })
   result: {
-    endedAlbums: EndedAlbumResponse[];
+    endedAlbums: EndedAlbumDto[];
   };
 
-  constructor(endedAlbums: EndedAlbumResponse[]) {
+  constructor(endedAlbums: EndedAlbumDto[]) {
     this.result = {
       endedAlbums,
     };
   }
 }
 
-export class EndedAlbumResponse {
+export class EndedAlbumDto {
   @ApiProperty()
   albumId: string;
   @ApiProperty()

--- a/server/src/album/dto/main-banner-response.dto.ts
+++ b/server/src/album/dto/main-banner-response.dto.ts
@@ -2,19 +2,19 @@ import { ApiProperty } from '@nestjs/swagger';
 import { GetAlbumBannerInfosTuple } from '../album.repository';
 
 export class MainBannerResponseDto {
-  @ApiProperty({ type: () => MainBannerResponse, isArray: true })
+  @ApiProperty({ type: () => MainBannerDto, isArray: true })
   result: {
-    bannerLists: MainBannerResponse[];
+    bannerLists: MainBannerDto[];
   };
 
-  constructor(bannerLists: MainBannerResponse[]) {
+  constructor(bannerLists: MainBannerDto[]) {
     this.result = {
       bannerLists,
     };
   }
 }
 
-export class MainBannerResponse {
+export class MainBannerDto {
   @ApiProperty()
   albumId: string;
   @ApiProperty()
@@ -48,7 +48,7 @@ export class MainBannerResponse {
     this.currentUserCount = currentUserCount;
   }
   static from(album: GetAlbumBannerInfosTuple, currentUserCount: number) {
-    return new MainBannerResponse(
+    return new MainBannerDto(
       album.albumId,
       album.albumName,
       album.albumTags,

--- a/server/src/album/dto/side-bar-response.dto.ts
+++ b/server/src/album/dto/side-bar-response.dto.ts
@@ -1,17 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { GetSideBarInfosTuple } from '../album.repository';
 
 export class SideBarResponseDto {
-  @ApiProperty({ type: () => SideBarResponse, isArray: true })
+  @ApiProperty({ type: () => SideBarDto, isArray: true })
   result: {
-    streamingAlbums: SideBarResponse[];
-    upComingAlbums: SideBarResponse[];
+    streamingAlbums: SideBarDto[];
+    upComingAlbums: SideBarDto[];
   };
 
-  constructor(
-    streamingAlbums: SideBarResponse[],
-    upComingAlbums: SideBarResponse[],
-  ) {
+  constructor(streamingAlbums: SideBarDto[], upComingAlbums: SideBarDto[]) {
     this.result = {
       streamingAlbums,
       upComingAlbums,
@@ -19,7 +15,7 @@ export class SideBarResponseDto {
   }
 }
 
-export class SideBarResponse {
+export class SideBarDto {
   @ApiProperty()
   albumId: string;
   @ApiProperty()
@@ -32,7 +28,7 @@ export class SideBarResponse {
     this.albumName = albumName;
     this.albumTags = albumTags;
   }
-  static from(album: GetSideBarInfosTuple) {
-    return new SideBarResponse(album.albumId, album.albumName, album.albumTags);
+  static from(album: SideBarDto) {
+    return new SideBarDto(album.albumId, album.albumName, album.albumTags);
   }
 }


### PR DESCRIPTION
close #140 
## 📋개요
앨범 상세 페이지의 앨범 상세 API를 구현하였습니다.
## 🕰️예상 리뷰시간
3분
## 📢상세내용
[앨범 상세 API 명세](https://befitting-stock-c1b.notion.site/52efcff84cbe4906984479104b0e5d68?pvs=74)

### 실행 결과
![image](https://github.com/user-attachments/assets/084eade9-aa12-4c84-b3b1-b6940d43164a)

## 💥특이사항
- duration은 초 단위 Number로 받아오고 있어서, 프론트에서 변환을 해줘야 할 것 같습니다.

- 개별 쿼리로 각각 받아오는 것으로 구현되어 있는데, 조인해서 한 번에 가져오는 것을 고려해보고 있습니다.