### PR TITLE
앨범 상세 코멘트 API

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -19,6 +19,8 @@ import { MusicRepository } from '@/music/music.repository';
 import { RoomModule } from '@/room/room.module';
 import { SchedulerService } from './common/scheduler/scheduler.service';
 import { ScheduleModule } from '@nestjs/schedule';
+import { Comment } from './comment/comment.entity';
+import { CommentModule } from './comment/comment.module';
 
 @Module({
   imports: [
@@ -32,6 +34,7 @@ import { ScheduleModule } from '@nestjs/schedule';
     AlbumModule,
     SongModule,
     RoomModule,
+    CommentModule,
     TypeOrmModule.forRoot({
       type: 'mysql',
       host: process.env.DB_HOST,
@@ -39,7 +42,7 @@ import { ScheduleModule } from '@nestjs/schedule';
       username: process.env.DB_USERNAME,
       password: process.env.DB_PASSWORD,
       database: process.env.DB_DATABASE,
-      entities: [Album, Song],
+      entities: [Album, Song, Comment],
     }),
   ],
   controllers: [AppController],

--- a/server/src/comment/comment.controller.ts
+++ b/server/src/comment/comment.controller.ts
@@ -1,0 +1,29 @@
+import { Body, Controller, Param, Post } from '@nestjs/common';
+import { CommentService } from './comment.service';
+import { ApiBody, ApiOperation, ApiParam } from '@nestjs/swagger';
+
+@Controller('comment')
+export class CommentController {
+  constructor(private readonly commentService: CommentService) {}
+
+  @ApiOperation({ summary: '댓글 추가' })
+  @ApiParam({ name: 'albumId', required: true, description: '앨범 id' })
+  @ApiBody({
+    description: '댓글 내용',
+    schema: { type: 'object', properties: { content: { type: 'string' } } },
+  })
+  @Post('/album/:albumId')
+  async createComment(
+    @Param('albumId') albumId: string,
+    @Body('content') content: string,
+  ): Promise<any> {
+    const commentResponse = await this.commentService.createComment(
+      albumId,
+      content,
+    );
+    return {
+      success: true,
+      commentResponse,
+    };
+  }
+}

--- a/server/src/comment/comment.controller.ts
+++ b/server/src/comment/comment.controller.ts
@@ -1,6 +1,7 @@
-import { Body, Controller, Param, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { CommentService } from './comment.service';
 import { ApiBody, ApiOperation, ApiParam } from '@nestjs/swagger';
+import { AlbumCommentResponseDto } from './dto/album-comment-response.dto';
 
 @Controller('comment')
 export class CommentController {
@@ -25,5 +26,14 @@ export class CommentController {
       success: true,
       commentResponse,
     };
+  }
+
+  @ApiOperation({ summary: '댓글 불러오기' })
+  @ApiParam({ name: 'albumId', required: true, description: '앨범 id' })
+  @Get('/album/:albumId')
+  async getAlbumComments(
+    @Param('albumId') albumId: string,
+  ): Promise<AlbumCommentResponseDto> {
+    return await this.commentService.getAlbumComments(albumId);
   }
 }

--- a/server/src/comment/comment.entity.ts
+++ b/server/src/comment/comment.entity.ts
@@ -1,0 +1,28 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+} from 'typeorm';
+import { Album } from '@/album/album.entity';
+
+@Entity()
+export class Comment {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ name: 'album_id', type: 'char', length: 36, nullable: false })
+  albumId: string;
+
+  @ManyToOne(() => Album, { nullable: false })
+  @JoinColumn({ name: 'album_id' })
+  album: Album;
+
+  @Column({ type: 'varchar', length: 200, nullable: false })
+  content: string;
+
+  @CreateDateColumn({ type: 'timestamp', name: 'created_at', nullable: false })
+  createdAt: Date;
+}

--- a/server/src/comment/comment.module.ts
+++ b/server/src/comment/comment.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Comment } from './comment.entity';
+import { CommentController } from './comment.controller';
+import { CommentService } from './comment.service';
+import { CommentRepository } from './comment.repository';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Comment])],
+  controllers: [CommentController],
+  providers: [CommentService, CommentRepository],
+})
+export class CommentModule {}

--- a/server/src/comment/comment.repository.ts
+++ b/server/src/comment/comment.repository.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Comment } from './comment.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class CommentRepository {
+  constructor(
+    @InjectRepository(Comment)
+    private readonly commentRepository: Repository<Comment>,
+  ) {}
+
+  async createComment(commentData: {
+    albumId: string;
+    content: string;
+  }): Promise<Comment> {
+    return await this.commentRepository.save(commentData);
+  }
+}

--- a/server/src/comment/comment.service.ts
+++ b/server/src/comment/comment.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { CommentRepository } from './comment.repository';
+import { Comment } from './comment.entity';
+
+@Injectable()
+export class CommentService {
+  constructor(private readonly commentRepository: CommentRepository) {}
+
+  async createComment(albumId: string, content: string): Promise<Comment> {
+    return await this.commentRepository.createComment({
+      albumId,
+      content,
+    });
+  }
+}

--- a/server/src/comment/comment.service.ts
+++ b/server/src/comment/comment.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { CommentRepository } from './comment.repository';
 import { Comment } from './comment.entity';
+import { AlbumCommentResponseDto } from './dto/album-comment-response.dto';
 
 @Injectable()
 export class CommentService {
@@ -11,5 +12,10 @@ export class CommentService {
       albumId,
       content,
     });
+  }
+
+  async getAlbumComments(albumId: string): Promise<AlbumCommentResponseDto> {
+    const comments = await this.commentRepository.getCommentInfos(albumId);
+    return new AlbumCommentResponseDto(comments);
   }
 }

--- a/server/src/comment/dto/album-comment-response.dto.ts
+++ b/server/src/comment/dto/album-comment-response.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AlbumCommentResponseDto {
+  @ApiProperty({ type: () => AlbumCommentDto, isArray: true })
+  result: {
+    albumComments: AlbumCommentDto[];
+  };
+  constructor(albumComments: AlbumCommentDto[]) {
+    this.result = {
+      albumComments,
+    };
+  }
+}
+
+export class AlbumCommentDto {
+  @ApiProperty()
+  albumId: string;
+  @ApiProperty()
+  content: string;
+}


### PR DESCRIPTION
close #141  close #142 
## 📋개요
앨범 상세 페이지에서 다음과 같은 API를 추가했습니다
- 코멘트 작성
- 코멘트 불러오기
## 🕰️예상 리뷰시간
5분
## 📢상세내용
[코멘트 추가 API 명세](https://befitting-stock-c1b.notion.site/14b510ea038e81adab66eea980a233d5?pvs=74)
[코멘트 불러오기 API 명세](https://befitting-stock-c1b.notion.site/6ef52fbdff8b4cec887c47e2dc5b7a8b?pvs=74)
### 실행 결과
![image](https://github.com/user-attachments/assets/b13eb7c6-5fb2-4fd0-8c5e-b51ba077fddd)  

![image](https://github.com/user-attachments/assets/20eb1ff5-f42a-4868-8d47-2c3909e1827a)

## 💥특이사항
- 혹시 몰라서 코멘트를 불러올 때, `created_at` 기준으로 오름차순으로 받아오게 했습니다.
~~시간이 남아 돈다면 정렬도 할 수 있겠군요~~
- 댓글은 200자로 DB단에서만 제한해두었습니다