### PR TITLE
앨범 데이터 변경 오류 수정

### DIFF
--- a/client/src/pages/StreamingPage/ui/StreamingPage.tsx
+++ b/client/src/pages/StreamingPage/ui/StreamingPage.tsx
@@ -16,13 +16,11 @@ export function StreamingPage() {
   const [roomInfo, setRoomInfo] = useState<RoomResponse | null>(null);
   const [songIndex, setSongIndex] = useState<number>(0);
 
-  const getRoomInfo = async () => {
-    if (!roomId) return;
+  const getRoomInfo = async (roomId: string) => {
     const res: RoomResponse = await publicAPI
       .getRoomInfo(roomId)
       .then((res) => res)
       .catch((err) => console.log(err));
-    console.log(res);
     setRoomInfo(res);
     setSongIndex(Number(res.trackOrder));
   };
@@ -31,7 +29,9 @@ export function StreamingPage() {
     // 페이지 진입 시 소켓 초기화
     reset();
     clearMessages();
+
     if (roomId) {
+      getRoomInfo(roomId);
       connect(roomId);
     }
 
@@ -40,10 +40,6 @@ export function StreamingPage() {
       reset();
     };
   }, [roomId]);
-
-  useEffect(() => {
-    getRoomInfo();
-  }, []);
 
   if (!isConnected) {
     return <StreamingErrorPage />;
@@ -78,7 +74,7 @@ export function StreamingPage() {
             <span className="text-lg">{userCount}명</span>
           </div>
         </div>
-        <Vote songs={roomInfo?.songResponseList} />
+        {roomInfo && <Vote songs={roomInfo.songResponseList} />}
         <ChattingContainer />
       </div>
     </div>

--- a/client/src/pages/StreamingPage/ui/StreamingPage.tsx
+++ b/client/src/pages/StreamingPage/ui/StreamingPage.tsx
@@ -8,6 +8,7 @@ import { useParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { RoomResponse } from '@/entities/album/types';
 import { publicAPI } from '@/shared/api/publicAPI';
+import { Person } from '@/shared/icon/Person';
 
 export function StreamingPage() {
   const { isConnected, connect, reset, userCount } = useSocketStore();
@@ -54,23 +55,11 @@ export function StreamingPage() {
           setSongIndex={setSongIndex}
         />
       )}
-
       <div className="bg-grayscale-900 flex-shrink-0 w-[340px] text-grayscale-100 px-8 pt-10 pb-8 flex flex-col relative">
         <div className="flex justify-between items-center mb-4">
           <div className="text-2xl font-bold">채팅</div>
           <div className="flex items-center gap-2">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-5 w-5"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-            >
-              <path
-                fillRule="evenodd"
-                d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
-                clipRule="evenodd"
-              />
-            </svg>
+            <Person />
             <span className="text-lg">{userCount}명</span>
           </div>
         </div>

--- a/client/src/shared/icon/Person.tsx
+++ b/client/src/shared/icon/Person.tsx
@@ -1,0 +1,16 @@
+export function Person() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className="h-5 w-5"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+    >
+      <path
+        fillRule="evenodd"
+        d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## 📋개요
close #152
다른 방으로 이동하면 앨범 데이터가 바뀌지 않는 오류

## 🕰️예상 리뷰시간
30초

## 📢상세내용
```tsx
  useEffect(() => {
    // 페이지 진입 시 소켓 초기화
    reset();
    clearMessages();

    if (roomId) {
      getRoomInfo(roomId);
      connect(roomId);
    }

    // 페이지 벗어날 때 소켓 리셋
    return () => {
      reset();
    };
  }, [roomId]);
```
- 소켓 연결할 때, 방 정보도 함께 불러오도록 구현
- roomId 즉, url이 바뀔 때마다 다시 소켓에 연결하고, 데이터를 불러옴

## 💥특이사항
- 채팅이랑 연결되어 있다보니, 불필요한 렌더링이 되고 있는지 확인해야함