### PR TITLE
메인 페이지 리팩토링

### DIFF
--- a/client/src/widgets/albums/ui/AlbumList.tsx
+++ b/client/src/widgets/albums/ui/AlbumList.tsx
@@ -25,7 +25,7 @@ export function AlbumList() {
     <div className="text-grayscale-50">
       <p className="mt-[70px] mb-7 text-3xl font-bold">최근 등록된 앨범</p>
       <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 xl:grid-cols-7 gap-9">
-        {endedAlbumList.endedAlbums.map((album) => (
+        {endedAlbumList.endedAlbums.slice(0, 6).map((album) => (
           <AlbumCard
             key={album.albumId}
             album={{

--- a/client/src/widgets/banner/types/index.ts
+++ b/client/src/widgets/banner/types/index.ts
@@ -1,0 +1,7 @@
+export type TimeZoneOffset = {
+  readonly KST: 9
+}
+
+export const TIMEZONE_OFFSET: TimeZoneOffset = {
+  KST: 9
+} as const;

--- a/client/src/widgets/banner/ui/BannerSlide.tsx
+++ b/client/src/widgets/banner/ui/BannerSlide.tsx
@@ -7,6 +7,12 @@ interface BannerSlideProps {
   banner: bannerData;
 }
 
+function convertToKTC(dateString: string) {
+  const date = new Date(dateString);
+  date.setHours(date.getHours() + 9);
+  return date.toISOString();
+}
+
 function splitDate(date: string) {
   const [dateString, timeString] = date.split('T');
   const [_, month, day] = dateString.split('-');
@@ -41,7 +47,7 @@ export function BannerSlide({ banner }: BannerSlideProps) {
         <div>
           <p className="font-bold text-2xl">{banner.artist}</p>
           <p className="text-gray-400 text-sm">
-            {splitDate(banner.releaseDate)} 예정
+            {splitDate(convertToKTC(banner.releaseDate))} 시작
           </p>
         </div>
       </div>

--- a/client/src/widgets/banner/ui/BannerSlide.tsx
+++ b/client/src/widgets/banner/ui/BannerSlide.tsx
@@ -2,6 +2,7 @@ import { bannerData } from '@/entities/room/types';
 import 'swiper/css';
 import 'swiper/css/pagination';
 import { useNavigate } from 'react-router-dom';
+import { TIMEZONE_OFFSET } from '../types';
 
 interface BannerSlideProps {
   banner: bannerData;
@@ -9,7 +10,7 @@ interface BannerSlideProps {
 
 function convertToKTC(dateString: string) {
   const date = new Date(dateString);
-  date.setHours(date.getHours() + 9);
+  date.setHours(date.getHours() + TIMEZONE_OFFSET.KST);
   return date.toISOString();
 }
 


### PR DESCRIPTION
close #149 
## 📋개요
- 배너 예상 시간 KTC로 변환
- 최근 스트리밍 앨범 6개만 불러오도록 변경
## 🕰️예상 리뷰시간
20초
## 📢상세내용
![image](https://github.com/user-attachments/assets/27438eff-6cfe-4242-a82f-667341cbb9a3)

## 💥특이사항
최근 스트리밍 앨범은 끝난 시간 기준으로 받아오고, 끝난 시간 기준 6개만 표시됩니다