### PR TITLE
hls error 수정

### DIFF
--- a/client/src/features/albumStreaming/lib/useStreamingPlayer.ts
+++ b/client/src/features/albumStreaming/lib/useStreamingPlayer.ts
@@ -7,11 +7,20 @@ export const useStreamingPlayer = (
   setSongIndex: (value: React.SetStateAction<number>) => void,
 ) => {
   const audioRef = useRef<HTMLMediaElement>(null);
+  const hlsRef = useRef<Hls | null>(null);
   const [isLoaded, setIsLoaded] = useState(false);
+  const destroyHls = useCallback(() => {
+    if (hlsRef.current) {
+      hlsRef.current.destroy();
+      hlsRef.current = null;
+    }
+  }, []);
   const createStreamUrl = (roomId: string) =>
     `${import.meta.env.VITE_API_URL}/api/music/${roomId}/playlist.m3u8`;
   const initializeHls = (audio: HTMLMediaElement, streamUrl: string) => {
+    destroyHls();
     const hls = new Hls(DEFAULT_STREAMING_CONFIG);
+    hlsRef.current = hls;
     hls.loadSource(streamUrl);
     hls.attachMedia(audio);
 


### PR DESCRIPTION
close #151 
## 📋개요
새로고침, 다음 노래 넘어갈 때 hls error 발생하던 것을 수정했습니다
## 🕰️예상 리뷰시간
10초
## 📢상세내용
- hlsRef를 통해 현재 활성화된 HLS 인스턴스를 추적할 수 있게 됨
- destroyHls()가 기존 인스턴스를 완전히 정리
- 새 인스턴스 추적
## 💥특이사항