### PR TITLE
앨범 발매 시간 자동 업데이트 스케쥴러에서 로컬 레디스에도 반영되게 변경

### DIFF
--- a/server/src/album/album.repository.ts
+++ b/server/src/album/album.repository.ts
@@ -37,6 +37,11 @@ export class AlbumRepository {
       .execute();
   }
 
+  async getReleaseDate(albumId: string): Promise<Date> {
+    const album = await this.repository.findOne({ where: { id: albumId } });
+    return album.releaseDate;
+  }
+
   async save(album: Album) {
     return await this.repository.save(album);
   }


### PR DESCRIPTION
## 📋개요

- 기존 스케쥴러가 클라우드에서 동작할때 시간 업데이트 되는 것이 클라우드 레디스에만 되고 로컬 레디스에는 안된것을 보완하고자 진행한 리팩토링입니다

## 🕰️예상 리뷰시간

5분

## 📢상세내용

- 팀원들이 대부분 ncloud vpc에 올라가있는 mysql + 로컬 레디스를 기반으로 개발을 진행하고 있음
- 해당 구조의 단점: 
  - DB에서의 releaseTimestamp 변경은 쉽지만 레디스는 쉽지 않음
  - DB에서의 시간 업데이트가 로컬 레디스에 반영이 되지를 않음
- 바뀐점: 기존 스케쥴러는 일정 시간이 지나면 mysql과 redis에 저장된 현재 값을 읽고 각자 독립적으로 30분씩 증가하도록 했는데 이제는 MySQL의 값을 레디스가 읽고 30분을 더해주는 구조로 변경이 되었습니다

## 💥특이사항

해당 스케쥴러를 사용하고 싶으면 사용하면 되는 플로우
1. 로컬환경을 실행시킨다
2. admin 페이지에 가서 테스트 앨범을 등록한다 (각자 다른게 좋습니다) -> 이렇게 하면 클라우드 MySQL DB랑 본인의 로컬 레디스에 정보가 저장이 됩니다
3. 서버에 저장되어있는 `.env`에 `TEST_ROOM_ID`로 본인의 테스트 앨범 ID를 입력합니다
4. 개발을 계속하다 스케쥴러에서 지정한 시간이 되면(매시 25분, 55분) 테스트 앨범의 releaseTimestamp가 현재보다 30분 뒤로 늦춰진 것을 볼수가 있다 -> 클라우드 DB와 로컬 redis에 둘다 반영이 됨. 새로운 앨범 릴리즈로 개발 계속 진행 가능

만약 오랜기간 로컬 서버를 껐다가 다시 테스트 앨범을 사용하고 싶으면: 
1. DB에 저장되어있는 releaseTimestamp를 본인이 원하는 시간으로 바꾸면 됩니다 (워크밴치 없으시면 제가 바꿔드리겠습니다)
2. 스케쥴러에 정해진 시간이 되면 redis에도 mysql에서 지정한 시간이랑 싱크가 맞게 될것입니다