### PR TITLE
앨범 관련 커스텀 에러 처리

### DIFF
--- a/server/src/common/exceptions/domain/album/album-not-found-by-timestamp.exception.ts
+++ b/server/src/common/exceptions/domain/album/album-not-found-by-timestamp.exception.ts
@@ -1,0 +1,11 @@
+import { HttpStatus } from '@nestjs/common';
+import { BaseException } from '../../base.exception';
+
+export class AlbumNotFoundByTimestampException extends BaseException {
+  constructor(albumId: string, timestamp: number) {
+    super('주어진 시간에 맞는 앨범을 찾을 수 없습니다.', HttpStatus.NOT_FOUND, {
+      albumId,
+      timestamp,
+    });
+  }
+}

--- a/server/src/common/exceptions/domain/album/album-not-found.exception.ts
+++ b/server/src/common/exceptions/domain/album/album-not-found.exception.ts
@@ -1,0 +1,8 @@
+import { HttpStatus } from '@nestjs/common';
+import { BaseException } from '../../base.exception';
+
+export class AlbumNotFoundException extends BaseException {
+  constructor(albumId: string) {
+    super('앨범을 찾을 수 없습니다.', HttpStatus.NOT_FOUND, { albumId });
+  }
+}

--- a/server/src/music/music.repository.ts
+++ b/server/src/music/music.repository.ts
@@ -2,7 +2,7 @@ import { AlbumNotFoundByTimestampException } from '@/common/exceptions/domain/al
 import { AlbumNotFoundException } from '@/common/exceptions/domain/album/album-not-found.exception';
 import { RoomNotFoundException } from '@/common/exceptions/domain/room/room-not-found.exception';
 import { REDIS_CLIENT } from '@/common/redis/redis.module';
-import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { RedisClientType } from 'redis';
 
 interface RoomSession {

--- a/server/src/music/music.repository.ts
+++ b/server/src/music/music.repository.ts
@@ -1,3 +1,4 @@
+import { AlbumNotFoundByTimestampException } from '@/common/exceptions/domain/album/album-not-found-by-timestamp.exception';
 import { AlbumNotFoundException } from '@/common/exceptions/domain/album/album-not-found.exception';
 import { RoomNotFoundException } from '@/common/exceptions/domain/room/room-not-found.exception';
 import { REDIS_CLIENT } from '@/common/redis/redis.module';
@@ -67,6 +68,6 @@ export class MusicRepository {
       }
       currentTime = songEndTime;
     }
-    throw new NotFoundException('No song found for the given timestamp');
+    throw new AlbumNotFoundByTimestampException(albumId, joinTimestamp);
   }
 }

--- a/server/src/music/music.repository.ts
+++ b/server/src/music/music.repository.ts
@@ -1,3 +1,4 @@
+import { RoomNotFoundException } from '@/common/exceptions/domain/room/room-not-found.exception';
 import { REDIS_CLIENT } from '@/common/redis/redis.module';
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { RedisClientType } from 'redis';
@@ -28,7 +29,7 @@ export class MusicRepository {
     const exists = await this.redisClient.exists(albumKey);
 
     if (!exists) {
-      throw new NotFoundException(`Room session ${albumId} not found`);
+      throw new RoomNotFoundException();
     }
 
     const [releaseTimestampStr, songStr] = await Promise.all([

--- a/server/src/music/music.repository.ts
+++ b/server/src/music/music.repository.ts
@@ -1,3 +1,4 @@
+import { AlbumNotFoundException } from '@/common/exceptions/domain/album/album-not-found.exception';
 import { RoomNotFoundException } from '@/common/exceptions/domain/room/room-not-found.exception';
 import { REDIS_CLIENT } from '@/common/redis/redis.module';
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
@@ -37,7 +38,7 @@ export class MusicRepository {
       this.redisClient.hGet(albumKey, 'songs'),
     ]);
     if (!releaseTimestampStr || !songStr) {
-      throw new NotFoundException(`Album ${albumId} not found`);
+      throw new AlbumNotFoundException(albumId);
     }
 
     return {


### PR DESCRIPTION
close #160 
## 📋개요
앨범 관련 커스텀 에러 처리를 진행했습니다.
## 🕰️예상 리뷰시간
30초
## 📢상세내용
`RoomNotFoundException` : 해당 세션을 찾을 수 없을 때 (이미 존재했음)
`AlbumNotFoundException` : 해당 앨범을 찾을 수 없을 때
`AlbumNotFoundByTimestampException` : joinTimestamp로 계산한 앨범이 맞지 않을 때
## 💥특이사항