### PR TITLE
broadcast 이벤트 발생 시 사용자 id를 받아 출력하도록 수정

### DIFF
--- a/client/src/entities/message/types.ts
+++ b/client/src/entities/message/types.ts
@@ -1,4 +1,5 @@
 export interface MessageData {
   userName: string;
   message: string;
+  userId: string;
 }

--- a/client/src/widgets/chatting/ui/Message.tsx
+++ b/client/src/widgets/chatting/ui/Message.tsx
@@ -1,13 +1,17 @@
 interface MessageData {
   userName: string;
   message: string;
+  userId: string;
 }
 
-export function Message({ userName, message }: MessageData) {
+export function Message({ userName, message, userId }: MessageData) {
   return (
     <div className="text-sm pb-4">
-      <span className="text-brand mr-4 whitespace-nowrap">{userName}</span>
-      <span className="text-grayscale-100 break-words">{message}</span>
+      <span className="text-brand mr-1 whitespace-nowrap">{userName}</span>
+      <span className="text-grayscale-400 mr-4 whitespace-nowrap">
+        #{userId}
+      </span>
+      <span className="text-grayscale-100 break-words text-[2]">{message}</span>
     </div>
   );
 }

--- a/client/src/widgets/chatting/ui/MessageList.tsx
+++ b/client/src/widgets/chatting/ui/MessageList.tsx
@@ -2,6 +2,7 @@ import { MessageData } from '@/entities/message/types';
 import { Message } from './Message';
 import './Chatting.css';
 import React, { useEffect } from 'react';
+
 interface MessageListProps {
   messages: MessageData[];
 }
@@ -16,7 +17,12 @@ function MessageList({ messages }: MessageListProps) {
   return (
     <div className="chatting overflow-y-auto mb-3 mt-24">
       {messages.map((msg, index) => (
-        <Message key={index} userName={msg.userName} message={msg.message} />
+        <Message
+          key={index}
+          userName={msg.userName}
+          userId={msg.userId}
+          message={msg.message}
+        />
       ))}
       <div ref={messageEndRef}></div>
     </div>


### PR DESCRIPTION
close #159 

## 📋개요

broadcast 이벤트가 발생하여 프론트에서 사용자 메시지를 출력할 때,  
사용자의 이름과 id, 메시지를 출력합니다.

## 🕰️예상 리뷰시간

20초

## 📢상세내용

- 기존 broadcast 이벤트에서 제공되는 데이터 중 userId를 입력받도록 수정했습니다.
- span 태그를 추가하여 해당 userId를 출력하도록 했습니다.
