### PR TITLE
투표 이벤트와 투표 조회 이벤트 분리

### DIFF
--- a/client/src/shared/store/useVoteStore.ts
+++ b/client/src/shared/store/useVoteStore.ts
@@ -4,11 +4,24 @@ export type VoteType = { votes: Record<string, string>; trackNumber: string };
 
 interface VoteState {
   voteData: VoteType;
+  showVote: (voteData: VoteType) => void;
   updateVote: (voteData: VoteType) => void;
 }
 
 export const useVoteStore = create<VoteState>((set) => ({
   voteData: { votes: {}, trackNumber: '' },
+  showVote: (voteData) =>
+    set((state) => ({
+      voteData: {
+        ...state.voteData,
+        ...voteData,
+      },
+    })),
   updateVote: (voteData) =>
-    set((state) => ({ voteData: { ...state.voteData, ...voteData } })),
+    set((state) => ({
+      voteData: {
+        ...state.voteData,
+        votes: voteData.votes,
+      },
+    })),
 }));

--- a/client/src/widgets/vote/useVote.ts
+++ b/client/src/widgets/vote/useVote.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { useVoteStore, VoteType } from '@/shared/store/useVoteStore.ts';
 
 export function useVote() {
-  const { voteData, updateVote } = useVoteStore();
+  const { voteData, showVote, updateVote } = useVoteStore();
   const { socket } = useSocketStore();
 
   useEffect(() => {
@@ -13,10 +13,16 @@ export function useVote() {
       updateVote(data);
     };
 
+    const handleVoteShow = (data: VoteType) => {
+      showVote(data);
+    };
+
     socket.on('voteUpdated', handleVoteUpdate);
+    socket.on('voteShow', handleVoteShow);
 
     return () => {
       socket.off('voteUpdated', handleVoteUpdate);
+      socket.off('voteShow', handleVoteShow);
     };
   }, [socket, updateVote]);
 

--- a/server/src/room/room.service.ts
+++ b/server/src/room/room.service.ts
@@ -67,4 +67,24 @@ export class RoomService {
       ? '0%'
       : `${((Number(value) / total) * 100).toFixed(0)}%`;
   }
+
+  getTotalVote(voteResult: { [key: string]: string }): number {
+    return Object.values(voteResult).reduce(
+      (acc, value) => acc + Number(value),
+      0,
+    );
+  }
+
+  async emitVoteUpdateToRoom(roomId: string) {
+    const voteResult: { [key: string]: string } =
+      await this.getVoteResult(roomId);
+
+    const totalVote = this.getTotalVote(voteResult);
+
+    Object.entries(voteResult).map(([key, value]) => {
+      voteResult[key] = this.calcPercentage(value, totalVote);
+    });
+
+    return voteResult;
+  }
 }


### PR DESCRIPTION
close #164 

## 📋개요

다른 사용자가 투표했을 때 해당 영역에 배경색이 주어지는 문제를 개선했습니다. 

## 🕰️예상 리뷰시간

## 📢상세내용

- show 소켓 이벤트와 updated 소켓 이벤트를 분리했습니다.
- sohw 이벤트는 사용자가 어떤 것을 선택했는 지에 대한 번호와, 전체적인 퍼센테이지 상태를 업데이트합니다.
- updated 이벤트는 다른 사용자가 선택했을 때 바뀐 투표 현황을 렌더링 하기 위해 사용됩니다.
  - 사용자가 어떤 것을 선택했는 지에 대한 정보는 다시 가져오지 않고, 전체적인 퍼센테이지  상태만 업데이트합니다.

## 💥특이사항

- DB와 직접적인 문제는 아니고, 사용자 경험을 위해 개선한 사항입니다.