### PR TITLE
앨범 태그 인식 안되던 문제 해결

### DIFF
--- a/server/src/admin/dto/album.dto.ts
+++ b/server/src/admin/dto/album.dto.ts
@@ -9,7 +9,7 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { SongDto } from './song.dto';
-import { Type } from 'class-transformer';
+import { Expose, Type } from 'class-transformer';
 
 export class AlbumDto {
   @IsNotEmpty()
@@ -37,6 +37,7 @@ export class AlbumDto {
   songs: SongDto[];
 
   @IsString()
+  @Expose({ name: 'albumTag' })
   tags: string;
 
   @IsNumber()


### PR DESCRIPTION
## 📋개요

- 기존에는 형식에 맞게 태그를 입력하더라도 DB에 저장이 되지 않고 나아가서 로컬 홈페이지에 나타나지 않은 문제가 있었습니다
<img width="777" alt="Screenshot 2024-11-28 at 4 53 45 PM" src="https://github.com/user-attachments/assets/e0c2c2ad-d26c-4411-98c1-ad98d9ce35dc">
<img width="836" alt="Screenshot 2024-11-28 at 4 53 55 PM" src="https://github.com/user-attachments/assets/8ed31aac-9567-434c-bd28-6b65e341e797">
- 이는 클라이언트와 서버 사이 통신 규격이 달라서 발생한 문제로 해당 에러를 해결하기 위한 PR 입니다

## 🕰️예상 리뷰시간

10초

## 📢상세내용

- 클라이언트에서 전달하는 `albumTag`항목은 서버에 지정되어있는 AlbumDto에서 정의된 tags와 다릅니다
- 그리하여 데코레이터 expose를 이용하여 albumTag를 tags와 매핑할 수 있도록 진행하여 albumDto를 파싱하는 과정에서 바로 처리 할 수 있도록 진행하였습니다

## 💥특이사항

결과:

<img width="762" alt="Screenshot 2024-11-28 at 4 54 52 PM" src="https://github.com/user-attachments/assets/05cfb5c1-c003-48b1-9127-1b78f6fbc77a">
<img width="200" alt="Screenshot 2024-11-28 at 4 55 03 PM" src="https://github.com/user-attachments/assets/48f84fe2-6f44-42db-a0e5-04957b61e73f">
