### PR TITLE
메인 페이지의 앨범 세션 응답값 개선

### DIFF
--- a/server/src/album/album.repository.ts
+++ b/server/src/album/album.repository.ts
@@ -130,7 +130,7 @@ export class AlbumRepository {
     return plainToInstance(SideBarDto, recentSideBarInfos);
   }
 
-  // 스트리밍 끝나는 시간 < currentTime <= 현재시간으로 부터 6시간 뒤
+  // 스트리밍 끝나는 시간 < currentTime <= 현재시간으로 부터 30분 뒤
   async getUpComingSideBarInfos(currentTime: Date): Promise<SideBarDto[]> {
     const upComingAlbumInfos = await this.dataSource
       .createQueryBuilder()
@@ -139,7 +139,7 @@ export class AlbumRepository {
       .where('release_date > :currentTime', {
         currentTime,
       })
-      .andWhere('release_date <= DATE_ADD(:currentTime, INTERVAL 6 HOUR)', {
+      .andWhere('release_date <= DATE_ADD(:currentTime, INTERVAL 30 MINUTE)', {
         currentTime,
       })
       .getRawMany();

--- a/server/src/album/album.repository.ts
+++ b/server/src/album/album.repository.ts
@@ -105,6 +105,7 @@ export class AlbumRepository {
       .andWhere('release_date <= DATE_ADD(:currentTime, INTERVAL 3 DAY)', {
         currentTime,
       })
+      .orderBy('release_date', 'ASC')
       .getRawMany();
 
     return plainToInstance(GetAlbumBannerInfosTuple, albumBannerInfos);
@@ -125,6 +126,7 @@ export class AlbumRepository {
           currentTime,
         },
       )
+      .orderBy('release_date', 'ASC') 
       .getRawMany();
 
     return plainToInstance(SideBarDto, recentSideBarInfos);
@@ -142,6 +144,7 @@ export class AlbumRepository {
       .andWhere('release_date <= DATE_ADD(:currentTime, INTERVAL 30 MINUTE)', {
         currentTime,
       })
+      .orderBy('release_date', 'ASC') 
       .getRawMany();
 
     return plainToInstance(SideBarDto, upComingAlbumInfos);


### PR DESCRIPTION
## 📋개요
- 사이드 바 `곧 시작합니다` 응답을 6시간에서 30분으로 축소했습니다
- 앨범 가장 빨리 시작하는 것부터 정렬되게 변경하였습니다
## 🕰️예상 리뷰시간
5초
## 📢상세내용

## 💥특이사항