### PR TITLE
볼륨 음소거 버튼 실행 조건 수정 및 mouse 이벤트 조건 수정

### DIFF
--- a/client/src/widgets/streaming/ui/AlbumInfo.tsx
+++ b/client/src/widgets/streaming/ui/AlbumInfo.tsx
@@ -47,10 +47,6 @@ export function AlbumInfo({
   };
 
   const handleVolumeMuted = () => {
-    if (audioRef.current) {
-      return;
-    }
-
     if (volume <= 0) {
       setVolume(backupVolume);
     }
@@ -60,8 +56,14 @@ export function AlbumInfo({
     }
   };
 
-  const handleMouseEnter = (e) => {
-    if (e.currentTarget === e.target) {
+  const handleMouseEnter = () => {
+    if (!isVolumeOpen) {
+      setIsVolumeOpen(!isVolumeOpen);
+    }
+  };
+
+  const handleMouseLeave = () => {
+    if (isVolumeOpen) {
       setIsVolumeOpen(!isVolumeOpen);
     }
   };
@@ -85,7 +87,7 @@ export function AlbumInfo({
       <div
         className={`fixed top-6 right-[364px] bg-grayscale-900 p-2 rounded-full flex flex-row items-center`}
         onMouseEnter={handleMouseEnter}
-        onMouseLeave={() => setIsVolumeOpen(!isVolumeOpen)}
+        onMouseLeave={handleMouseLeave}
       >
         <input
           type="range"


### PR DESCRIPTION
## 📋개요

부정 연산자 누락으로 인해 볼륨 음소거 버튼 미작동 문제 해결 및 볼륨 조절 바를 보여주는 이벤트 조건 수정

## 🕰️예상 리뷰시간

1분

## 📢상세내용

- 음소거 시 audio.ref의 current가 존재하는 지에 대한 조건 확인 로직을 제거했습니다.
- mouse enter 및 mouse leave 시 isVolumeOpen 상태를 확인해서 이벤트가 실행될 수 있도록 수정했습니다.