### PR TITLE
fix: 초기 vote에 관한 정보 불러오기

### DIFF
--- a/client/src/shared/store/useSocketStore.ts
+++ b/client/src/shared/store/useSocketStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { Socket } from 'socket.io-client';
 import { createSocket } from '../api/socket';
+import { useVoteStore } from './useVoteStore';
 
 interface SocketState {
   socket: Socket | null;
@@ -31,6 +32,7 @@ export const useSocketStore = create<SocketState>((set, get) => ({
     }
 
     const newSocket = createSocket(newRoomId);
+    const voteStore = useVoteStore.getState();
 
     newSocket.on('connect', () =>
       set({
@@ -47,6 +49,10 @@ export const useSocketStore = create<SocketState>((set, get) => ({
         roomId: null,
       }),
     );
+
+    newSocket.on('voteShow', (data) => {
+      voteStore.showVote(data);
+    });
 
     newSocket.on(
       'roomUsersUpdated',


### PR DESCRIPTION
## 📋개요

- 기존에 처음 스트리밍 룸을 들어올때 투표 항목들이 제대로 보이지 않는 문제가 있었습니다 (특히 로컬에서 더 자주 일어나는 문제). 
- 이는 서버에서 handleConnection을 보낼때 클라이언트에서 투표에 관한 정보를 처리하지 않고 있었기에 발생한 문제임으로 해당 부분을 수정한 PR입니다
<img width="308" alt="Screenshot 2024-12-02 at 1 42 32 PM" src="https://github.com/user-attachments/assets/c378ca25-18f0-4c1f-83ed-db4305c8c3f5">

## 🕰️예상 리뷰시간

30초

## 📢상세내용

- 모든 vote에 관한 정보는 서버에서 `socket.emit('voteShow')`의 형태로 클라이언트에서 받아 state을 업데이트하고 있습니다
- 스트리밍 방에 들어가자마자 클라이언트와 서버는 handshaking을 통해 초기화를 진행하게 되는데 이때 서버에서 `voteShow`를 우선 초기화의 목적으로 한번 보내고 있습니다
```js
//handleConnection에 들어가 있는 코드
client.emit('voteShow', {
    votes: voteResult,
    trackNumber: votedTrackNumber,
  });
```
- 클라이언트에서는 초기화를 진행할때 `useSocketStore()`에서 진행을 합니다. 다만 이때 기존 코드에는 voteShow에 관한 핸들러 함수가 등록이 되어있지 않습니다
- 클라이언트와 서버의 handshaking이 이루어지고 socket을 클라이언트에서 받은 이후로 useVote.ts에서 voteShow에 관한 핸들러가 등록이 됨으로 이후에는 vote에 관한 정보를 얻을수가 있습니다
- 결과적으로 초기 투표 정보가 누락되는 문제 발생합니다
- 그렇기에 초기 handshaking 단계에서 바로 vote에 관한 정보를 받고 처리할 수 있도록 핸들러를 등록을 해주도록 수정하였습니다



## 💥특이사항

- state이랑 컴포넌트에 관한 이해도가 확실하지는 않아서 해당 방식으로 초기화를 진행해도 괜찮은지 한번만 확인 부탁드립니다!
- 이 pr 이후에 제목에 관한 pr은 별도로 올라갈 예정입니다
<img width="315" alt="Screenshot 2024-12-02 at 1 57 14 PM" src="https://github.com/user-attachments/assets/9dba5f2d-4468-4d49-9a62-af0b4859b777">
