### PR TITLE
플레이리스트 하단 바 개선

### DIFF
--- a/client/src/features/songDetail/ui/SongDetailHeader.tsx
+++ b/client/src/features/songDetail/ui/SongDetailHeader.tsx
@@ -15,18 +15,24 @@ export function SongDetailHeader({
   setIsOpen,
   setCategory,
 }: SongDetailHeaderProps) {
+  const handleCategoryClick = (selectedCategory: string) => {
+    if (!isOpen) {
+      setIsOpen(true);
+    }
+    setCategory(selectedCategory);
+  };
   return (
     <div className="flex flex-row justify-between px-6 py-4 items-center bg-grayscale-900 rounded-t-lg">
       <div className="flex flex-row space-x-4">
         <CategoryButton
           isActive={category === CATEGORIES.LYRICS}
-          onClick={() => isOpen && setCategory(CATEGORIES.LYRICS)}
+          onClick={() => handleCategoryClick(CATEGORIES.LYRICS)}
         >
           가사
         </CategoryButton>
         <CategoryButton
           isActive={category === CATEGORIES.PLAYLIST}
-          onClick={() => isOpen && setCategory(CATEGORIES.PLAYLIST)}
+          onClick={() => handleCategoryClick(CATEGORIES.PLAYLIST)}
         >
           플레이리스트
         </CategoryButton>


### PR DESCRIPTION
close #183 
## 📋개요
플레이리스트 하단 바 기능을 개선했습니다
## 🕰️예상 리뷰시간
30초
## 📢상세내용
이제 스트리밍 페이지에서 하단 바의 가사 / 플레이리스트를 눌러도 오른쪽 버튼처럼 동작합니다.
## 💥특이사항