### PR TITLE
노래 제목 vote에서 자르기

### DIFF
--- a/client/src/widgets/vote/ui/Vote.tsx
+++ b/client/src/widgets/vote/ui/Vote.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown } from '@/shared/icon/ChevronDown';
 import { useState } from 'react';
-import { useSocketStore } from '@/shared/store/useSocketStore';
+import { useSocketStore } from '@/shared/store/useSocketStore.ts';
 import { SongData } from '@/entities/album/types.ts';
 import { useVote } from '@/widgets/vote/useVote.ts';
 import './ScrollBar.css';
@@ -40,16 +40,16 @@ export function Vote({ songs }: { songs: SongData[] }) {
             className={`vote select-none relative h-full my-3 flex w-full justify-between overflow-x-hidden rounded-lg  ${voteData.trackNumber === String(index + 1) ? 'hover bg-brand text-grayscale-900' : 'hover:bg-grayscale-600 cursor-pointer'}`}
             onClick={() => handleVoteClick(String(index + 1))}
           >
-            <div>
+            <div className="flex-1 min-w-0">
               <div
                 className={`votebg absolute ${voteData.trackNumber === String(index + 1) ? '' : 'bg-grayscale-800'} text-grayscale-300 text-shadow h-full rounded-md z-0`}
                 style={{ width: `${item}` }}
               ></div>
-              <p className={`relative mb-1 px-3 py-3 rounded-md z-10`}>
+              <p className={`relative mb-1 px-3 py-3 rounded-md z-10 truncate`}>
                 {songs[index].title}
               </p>
             </div>
-            <div className={'w-10 w-20'}>
+            <div className="flex-shrink-0 w-20">
               <p className={`mb-1 px-3 py-3 rounded-md z-10`}>{item}</p>
             </div>
           </div>

--- a/client/src/widgets/vote/ui/Vote.tsx
+++ b/client/src/widgets/vote/ui/Vote.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown } from '@/shared/icon/ChevronDown';
 import { useState } from 'react';
-import { useSocketStore } from '@/shared/store/useSocketStore.ts';
+import { useSocketStore } from '@/shared/store/useSocketStore';
 import { SongData } from '@/entities/album/types.ts';
 import { useVote } from '@/widgets/vote/useVote.ts';
 import './ScrollBar.css';


### PR DESCRIPTION
## 📋개요

- 노래 제목이 길때 제목을 다 보여주지 말고 ...으로 truncate한 것을 출력할 수 있도록 수정

## 🕰️예상 리뷰시간

5초

## 📢상세내용\

- `flex-1 min-w-0`: 공간을 최대한 차지하도록 하면서 텍스트가 부모 영역안에 머무를수 있도록 제한
- `truncate`: 텍스트가 컨테이너를 벗어날 때 (...) 표시
- `flex-shrink-0`: 투표수 영역 보존

## 💥특이사항

<img width="310" alt="Screenshot 2024-12-02 at 10 25 21 PM" src="https://github.com/user-attachments/assets/e6a65a01-0e17-46ad-8d26-c339c37f4f9b">
