### PR TITLE
노래 저장 트랜젝션에 관한 문제점 수정

### DIFF
--- a/server/src/admin/admin.service.ts
+++ b/server/src/admin/admin.service.ts
@@ -107,9 +107,6 @@ export class AdminService {
     return result.Location;
   }
 
-  // forEach는 비동기 작업을 기다리지 않고 단순 반복만 수행
-  // repository.save()가 배열을 받으면 내부적으로 단일 트랜잭션으로 처리
-  // 두 번째 방식은 실제로 하나의 쿼리로 처리되어 성능상 이점도 있음
   async saveSongs(songs: Song[], albumId: string) {
     const songsToSave = songs.map(
       (song) => new Song(new SongSaveDto({ ...song, albumId: albumId })),

--- a/server/src/admin/admin.service.ts
+++ b/server/src/admin/admin.service.ts
@@ -107,14 +107,15 @@ export class AdminService {
     return result.Location;
   }
 
+  // forEach는 비동기 작업을 기다리지 않고 단순 반복만 수행
+  // repository.save()가 배열을 받으면 내부적으로 단일 트랜잭션으로 처리
+  // 두 번째 방식은 실제로 하나의 쿼리로 처리되어 성능상 이점도 있음
   async saveSongs(songs: Song[], albumId: string) {
-    console.log('Songs to save:', songs);
-    await Promise.all(
-      songs.map(async (song) => {
-        const songDto = new SongSaveDto({ ...song, albumId: albumId });
-        return await this.songRepository.save(new Song(songDto));
-      }),
+    const songsToSave = songs.map(
+      (song) => new Song(new SongSaveDto({ ...song, albumId: albumId })),
     );
+
+    await this.songRepository.saveSongList(songsToSave);
   }
 
   async saveAlbumCoverAndBanner(files: UploadedFiles, albumId: string) {

--- a/server/src/admin/dto/album.dto.ts
+++ b/server/src/admin/dto/album.dto.ts
@@ -9,7 +9,7 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { SongDto } from './song.dto';
-import { Expose, Type } from 'class-transformer';
+import { Expose, Transform, Type } from 'class-transformer';
 
 export class AlbumDto {
   @IsNotEmpty()

--- a/server/src/admin/dto/album.dto.ts
+++ b/server/src/admin/dto/album.dto.ts
@@ -38,6 +38,7 @@ export class AlbumDto {
 
   @IsString()
   @Expose({ name: 'albumTag' })
+  @Transform(({ value, obj }) => value || obj.tags || '')
   tags: string;
 
   @IsNumber()

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,12 +1,8 @@
 import { Logger, Module } from '@nestjs/common';
 import { AppController } from '@/app.controller';
-import { AppService } from '@/app.service';
 import { CommonModule } from '@/common/common.module';
 import { ConfigModule } from '@nestjs/config';
 import { RedisModule } from '@/common/redis/redis.module';
-import { RoomRepository } from './room/room.repository';
-import { RoomController } from '@/room/room.controller';
-import { RoomGateway } from './room/room.gateway';
 import { MusicModule } from './music/music.module';
 import { EmojiModule } from './emoji/emoji.module';
 import { AdminModule } from './admin/admin.module';
@@ -46,6 +42,6 @@ import { CommentModule } from './comment/comment.module';
     }),
   ],
   controllers: [AppController],
-  providers: [Logger, AppService, MusicRepository, SchedulerService],
+  providers: [Logger, MusicRepository, SchedulerService],
 })
 export class AppModule {}

--- a/server/src/app.service.ts
+++ b/server/src/app.service.ts
@@ -1,8 +1,0 @@
-import { Injectable } from '@nestjs/common';
-
-@Injectable()
-export class AppService {
-  getHello(): string {
-    return 'Hello World! ASDASD';
-  }
-}

--- a/server/src/song/song.repository.ts
+++ b/server/src/song/song.repository.ts
@@ -21,4 +21,8 @@ export class SongRepository {
   async save(song: Song) {
     return this.repository.save(song);
   }
+
+  async saveSongList(song: Song[]) {
+    return this.repository.save(song);
+  }
 }


### PR DESCRIPTION
## 📋개요

- 노래들중 하나의 제목 길이가 mysql db의 limit인 30을 넘어갈 경우 internal server error 발생합니다
- 원래는 모든 앨범 정보 및 노래 정보에 관한 mysql db 저장이 롤백이 되어야하는데 기존 코드로는 해당 노래를 제외한 나머지 정보들은 여전히 저장이 되어있는 상태입니다 (롤백 처리가 안됨)
- 이로 인하여 메인페이지에는 여전히 앨범 정보 및 노래들을 볼수가 있습니다

## 🕰️예상 리뷰시간

5분

## 📢상세내용

### 해당 버그 발생 이유

- 노래를 저장하는 `adminService.saveSongs`에서 트랜잭션 처리가 잘 진행이 되지 않았습니다
- 기존 코드는 Promise.all을 사용해 비동기 처리는 잘 되지만, 각각의 save 호출이 별도의 트랜잭션으로 실행되기 때문에 문제가 있습니다
- 이로 인하여 하나의 트랜잭션 안에서 모든 저장이 처리되도록 수정했습니다

### 결과

- 이제 노래중 하나라도 저장이 실패가 될 경우 같은 앨범의 다른 노래들까지 같이 트랜잭션으로 묶여 롤백이 진행이 됩니다
- 기존 앨범 롤백은 문제가 없었음으로 해당 노래의 앨범정보도 성공적으로 롤백이 잘 되는 것을 테스트했습니다

### Song을 배열로 묶어서 일괄적으로 처리하게 됨에 따른 이점

- repository.save()가 Song의 배열을 받으면 내부적으로 단일 트랜잭션으로 처리하기에 비동기 문제가 발생하지 않습니다 (테스트코드 통과)
- 해당 방식은 실제로 하나의 쿼리로 처리되어 성능상 이점도 있습니다

## 💥특이사항

- albumDto를 서버 내부에서 tags의 attribute로 값을 집어넣게 하게끔 하려고 (테스트 코드에서 사용하고 있음) 데코레이터로 `@Transform(({ value, obj }) => value || obj.tags || '')`를 도입했습니다
- 이로 인하여 외부에서는 expose 지정 attribute인 albumTags로 클라이언트에서 전송이 가능하고 서버 내에서는 여전히 albumDto 지정 양식에 맞게 tags사용이 가능합니다