### PR TITLE
백엔드 도커 이미지 경량화

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,17 +1,33 @@
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json yarn.lock .yarnrc.yml tsconfig.json ./
+COPY .yarn .yarn
+COPY server server
+
+RUN corepack enable
+RUN yarn install
+
+WORKDIR /app/server
+RUN yarn install
+RUN yarn build
+
 FROM node:22-alpine
 
 WORKDIR /app
 
 RUN apk add --no-cache ffmpeg
+RUN corepack enable
 
-COPY package.json yarn.lock .yarnrc.yml tsconfig.json ./
-COPY .yarn .yarn
-COPY server/ server/
+COPY --from=builder /app/server/package.json ./package.json
+COPY --from=builder /app/yarn.lock ./yarn.lock
+COPY --from=builder /app/.yarnrc.yml ./.yarnrc.yml
+COPY --from=builder /app/.yarn ./.yarn
+COPY --from=builder /app/server/dist ./dist
+COPY server/.env ./.env
 
-RUN corepack enable && \
-    yarn install
-
-WORKDIR /app/server
+RUN yarn workspaces focus --production --all
 
 EXPOSE 3000
-CMD ["yarn", "start"]
+CMD ["node", "dist/main.js"]


### PR DESCRIPTION
close #202 

## 📋개요

백엔드 도커 이미지를 최소화하기 위해 Dockerfile을 수정했습니다.

## 🕰️예상 리뷰시간

3분

## 📢상세내용

- nestjs 프로젝트를 직접 실행하는 방식에서 build 후 dist 파일을 실행하는 구조로 수정되었습니다.
- 도커 이미지가 478MB 가량 축소되었습니다.

![image](https://github.com/user-attachments/assets/c05c3f9a-f7e1-4335-8904-4896361678ff)

실행 확인

![image](https://github.com/user-attachments/assets/7068c8e2-7dd2-4c90-b452-12ce986bcd9a)